### PR TITLE
ci: simplify package building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,20 +16,8 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: 3.7
-      - name: Install PEP517
-        run: >-
-          python -m
-          pip install
-          pep517
-          --user
-      - name: Build a binary wheel and a source tarball
-        run: >-
-          python -m
-          pep517.build
-          --source
-          --binary
-          --out-dir dist/
-          .
+      - name: Build package
+        run: make build-package
       - name: Publish distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@master
         with:
@@ -58,8 +46,7 @@ jobs:
           pip install -r ./docs/requirements.txt
           pip install -e .
       - name: Build the Documentation
-        run: |
-          mkdocs build
+        run: make build-docs
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -145,12 +145,13 @@ pull-master:
 	@echo ""
 
 .PHONY: build-package
-build-package:
+build-package: clean
 	@echo "------------------------"
 	@echo "- Building the package -"
 	@echo "------------------------"
 
-	python -m pep517.build --source --binary --out-dir dist/ .
+	python setup.py -q bdist_wheel
+	python setup.py -q sdist
 
 	@echo ""
 
@@ -171,6 +172,17 @@ upload-pypi:
 	@echo "-----------------------------"
 
 	twine upload -r pypi dist/*
+
+	@echo ""
+
+
+.PHONY: upload-testing-pypi
+upload-testing-pypi:
+	@echo "-------------------------------------"
+	@echo "- Uploading package to pypi testing -"
+	@echo "-------------------------------------"
+
+	twine upload -r testpypi dist/*
 
 	@echo ""
 

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,25 @@
 import re
 from glob import glob
 from os.path import basename, splitext
+from subprocess import getoutput
 
 from setuptools import find_packages, setup
+from setuptools.command.install import install
+
+
+# ignore: cannot subclass install, has type Any. And what would you do?
+class PostInstall(install):  # type: ignore
+    """Install direct dependency.
+
+    Pypi doesn't allow uploading packages with direct dependencies, so we need to
+    install them manually.
+    """
+
+    def run(self) -> None:
+        """Install dependencies."""
+        install.run(self)
+        print(getoutput("pip install git+git://github.com/lyz-code/deepdiff@master"))
+
 
 # Avoid loading the package to extract the version
 with open("src/repository_orm/version.py") as fp:
@@ -24,6 +41,7 @@ setup(
         "Library to ease the implementation of the repository pattern in "
         "Python projects."
     ),
+    cmdclass={"install": PostInstall},
     author="Lyz",
     author_email="lyz-code-security-advisories@riseup.net",
     license="GNU General Public License v3",
@@ -50,7 +68,6 @@ setup(
         "Natural Language :: English",
     ],
     install_requires=[
-        "deepdiff @ git+git://github.com/lyz-code/deepdiff@master",
         "pydantic",
         "pypika",
         "pymysql",


### PR DESCRIPTION
ci: install direct dependencies in PostInstall

Pypi doesn't allow uploading packages with direct dependencies, so we need to
install them manually.

<!--
Thank you for sending a pull request!

Please describe what the change is, trying to link it with open issues.
-->

## Checklist

* [ ] Add test cases to all the changes you introduce
* [ ] Update the documentation for the changes
