### PR TITLE
fix: use entity typevar for abstract repository definition

### DIFF
--- a/src/repository_orm/adapters/abstract.py
+++ b/src/repository_orm/adapters/abstract.py
@@ -1,10 +1,12 @@
 """Define the interface of the repositories."""
 
 import abc
-from typing import Dict, List, Type, Union
+from typing import Dict, List, Type, TypeVar, Union
 
 from ..exceptions import EntityNotFoundError
-from ..model import Entity
+from ..model import Entity as EntityModel
+
+Entity = TypeVar("Entity", bound=EntityModel)
 
 
 class AbstractRepository(abc.ABC):

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -114,9 +114,7 @@ def test_repository_can_save_an_entity_without_id(
 
     saved_entity = repo.last(type(inserted_entity))
     assert saved_entity.id_ == inserted_entity.id_ + 1
-    # ignore: Entity doesn't have a name attribute, but all the models in the test
-    #   cases do.
-    assert saved_entity.name == "Entity without id"  # type: ignore
+    assert saved_entity.name == "Entity without id"
 
 
 def test_repository_cant_save_an_entity_with_a_negative_id(
@@ -135,9 +133,7 @@ def test_repository_cant_save_an_entity_with_a_negative_id(
 
     saved_entity = repo.last(type(inserted_entity))
     assert saved_entity.id_ == inserted_entity.id_ + 1
-    # ignore: Entity doesn't have a name attribute, but all the models in the test
-    #   cases do.
-    assert saved_entity.name == "Entity with negative id"  # type: ignore
+    assert saved_entity.name == "Entity with negative id"
 
 
 def test_repo_add_entity_is_idempotent(


### PR DESCRIPTION
Otherwise the `last` and `first` methods will assume that the returning
object is Entity instead of the subclass.

<!--
Thank you for sending a pull request!

Please describe what the change is, trying to link it with open issues.
-->

## Checklist

* [x] Add test cases to all the changes you introduce
* [x] Update the documentation for the changes
