### PR TITLE
Fix/support str ids back

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/lyz-code/cookiecutter-python-project",
-  "commit": "990a3ed0c3ea05d49e6a14b59029900a88437014",
+  "commit": "82cdf790b9326f9892e25702a64c2af33c3d3e6c",
   "checkout": null,
   "context": {
     "cookiecutter": {

--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/lyz-code/cookiecutter-python-project",
-  "commit": "82cdf790b9326f9892e25702a64c2af33c3d3e6c",
+  "commit": "7ddf0d825eb90ba7561141cf8944cdb2cde13760",
   "checkout": null,
   "context": {
     "cookiecutter": {

--- a/.cruft.json
+++ b/.cruft.json
@@ -1,24 +1,25 @@
 {
-    "template": "git@github.com:lyz-code/cookiecutter-python-project.git",
-    "commit": "74f3b8fdccb96b032b851b9735e2044e36f30a9b",
-    "context": {
-        "cookiecutter": {
-            "project_name": "Repository Pattern",
-            "project_slug": "repository-pattern",
-            "project_description": "Library to ease the implementation of the repository pattern in python projects.",
-            "requirements": "deepdiff[murmur],pydantic,pypika,pymysql, yoyo-migrations",
-            "configure_command_line": "False",
-            "read_configuration_from_yaml": "False",
-            "github_user": "lyz-code",
-            "github_token_pass_path": "internet/github.lyz-code.api_token",
-            "pypi_token_pass_path": "internet/pypi.token",
-            "test_pypi_token_pass_path": "internet/test.pypi.token",
-            "author": "Lyz",
-            "author_email": "lyz-code-security-advisories@riseup.net",
-            "security_advisories_email": "lyz-code-security-advisories@riseup.net",
-            "project_underscore_slug": "repository_pattern",
-            "_template": "git@github.com:lyz-code/cookiecutter-python-project.git"
-        }
-    },
-    "directory": null
+  "template": "https://github.com/lyz-code/cookiecutter-python-project",
+  "commit": "990a3ed0c3ea05d49e6a14b59029900a88437014",
+  "checkout": null,
+  "context": {
+    "cookiecutter": {
+      "project_name": "Repository ORM",
+      "project_slug": "repository-orm",
+      "project_description": "Library to ease the implementation of the repository pattern in python projects.",
+      "requirements": "",
+      "configure_command_line": "False",
+      "read_configuration_from_yaml": "False",
+      "github_user": "lyz-code",
+      "github_token_pass_path": "internet/github.lyz-code.api_token",
+      "pypi_token_pass_path": "internet/pypi.token",
+      "test_pypi_token_pass_path": "internet/test.pypi.token",
+      "author": "Lyz",
+      "author_email": "lyz-code-security-advisories@riseup.net",
+      "security_advisories_email": "lyz-code-security-advisories@riseup.net",
+      "project_underscore_slug": "repository_orm",
+      "_template": "https://github.com/lyz-code/cookiecutter-python-project"
+    }
+  },
+  "directory": null
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,10 +44,8 @@ jobs:
         with:
           python-version: 3.7
       - name: Install dependencies
-        run: |
+        run: >-
           pip install -r ./docs/requirements.txt
-          # To remove when PR is merged
-          pip install git+git://github.com/lyz-code/deepdiff@master
           pip install -e .
       - name: Build the Documentation
         run: make build-docs

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,0 +1,25 @@
+---
+name: Install
+on:  # yamllint disable-line rule:truthy
+  schedule:
+    - cron: 21 08 * * *
+
+jobs:
+  Install:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 3
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install the program
+        run: pip install repository-orm
+      - name: Test the program works
+        run: |-
+          python -c "import repository_orm.version;
+          print(repository_orm.version.version_info())"

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ update:
 	@echo "- Updating dependencies -"
 	@echo "-------------------------"
 
+	pip install -U pip
+
 	rm requirements.txt
 	touch requirements.txt
 	pip-compile -Ur --allow-unsafe

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ test-examples:
 	@echo "--------------------"
 
 	@find docs/examples -type f -name '*.py' | xargs -I'{}' sh -c 'python {} >/dev/null 2>&1 || (echo "{} failed" ; exit 1)'
+	pytest docs/examples/*
 
 	@echo ""
 

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,8 @@ black = black --target-version py37 src docs/examples tests setup.py
 
 .PHONY: install
 install:
-
 	python -m pip install -U setuptools pip
 	pip install -r requirements-dev.txt
-	pip install git+git://github.com/lyz-code/deepdiff@master
 	pip install -e .
 	pre-commit install
 
@@ -177,7 +175,6 @@ upload-pypi:
 	twine upload -r pypi dist/*
 
 	@echo ""
-
 
 .PHONY: upload-testing-pypi
 upload-testing-pypi:

--- a/docs/adr/001-entity_id_definition.md
+++ b/docs/adr/001-entity_id_definition.md
@@ -3,7 +3,12 @@ Date: 2021-04-15
 # Status
 <!-- What is the status? Draft, Proposed, Accepted, Rejected, Deprecated or Superseded?
 -->
-Accepted
+Superseeded
+
+!!! warning "It has been partially superseeded by [002](002-support_string_ids.md)"
+
+    String ids are again supported.
+
 
 # Context
 <!-- What is the issue that we're seeing that is motivating this decision or change? -->

--- a/docs/adr/002-support-string-ids.md
+++ b/docs/adr/002-support-string-ids.md
@@ -1,0 +1,26 @@
+Date: 2021-04-16
+
+# Status
+<!-- What is the status? Draft, Proposed, Accepted, Rejected, Deprecated or Superseded?
+-->
+Accepted
+
+# Context
+<!-- What is the issue that we're seeing that is motivating this decision or change? -->
+In version 0.3.0 we dropped support for string ids, and that was a bad decision,
+as there are already projects that use it.
+
+The reason of deprecation was because the new feature to auto increment the ID of
+the entities that hadn't set it, wasn't "easy" to implement for strings.
+
+# Proposals
+<!-- What are the possible solutions to the problem described in the context -->
+Restore the support for string ids, but without the auto increment feature. If
+you're using string ids is probably because you have an id generator or you're
+getting them from outside sources.
+
+# Decision
+<!-- What is the change that we're proposing and/or doing? -->
+
+# Consequences
+<!-- What becomes easier or more difficult to do because of this change? -->

--- a/docs/adr/003-make_entity_models_optional_arguments.md
+++ b/docs/adr/003-make_entity_models_optional_arguments.md
@@ -1,0 +1,90 @@
+Date: 2021-04-28
+
+# Status
+<!-- What is the status? Draft, Proposed, Accepted, Rejected, Deprecated or Superseded?
+-->
+Accepted
+
+# Context
+<!-- What is the issue that we're seeing that is motivating this decision or change? -->
+Some applications need to do operations on all or a subset of entity types in
+the repository, for example for the `get`, `search`, `all`, `first` or `last`.
+
+Right now the `entity_model` is a mandatory argument for these methods, that
+means that the code calling the repository needs to be aware of all the entity
+models inside the repository and call the methods for each of them.
+
+# Proposals
+<!-- What are the possible solutions to the problem described in the context -->
+To solve it, we should change the `entity_model` an argument to a more flexible
+type `Union[Type[Entity], List[Type[Entity]], None]`. That change carries some
+side effects:
+
+* We need to add logic at repository level to process one, a subset or all the
+    entity types.
+* Some repositories (tinydb and pypika) used the `entity_model` to build the
+    entity, if it's not specified, we need to build the logic that lets them
+    build the entities from their data.
+* The calls to the methods without specifying the `entity_model` can have
+    a worse performance.
+
+## Build the Entities from their data
+
+To build the entities from the data we need those methods to be able to link
+that data to a model type, we can either:
+
+* Delegate that functionality to the application using the repository.
+* Configure the repositories in a way that we can deduce the model from the data
+    stored in itself.
+
+The first solution means that each application will need to implement and
+maintain that code, which will lead to more maintenance and duplicated code, but
+a simpler repository configuration.
+
+The second solution will mean that the code for the methods is more complex
+and/or the repository initialization needs more arguments.
+
+We already store the key information that tells which model does the data belong
+to. In the tinydb repo it's stored as an attribute `_model_type`, and in the
+pypika repo is stored as tables names. The fake repo doesn't have this problem.
+
+If we initialize the repository with a `models` optional argument, with a list
+of the entity models, we can create an internal `models` attribute that holds
+a dictionary with the key equal to the value stored in the repos, and the value
+the model type. If the user doesn't provide this argument at repo
+initialization, it will be supposed that it will give the `entity_model` on each
+of the repo methods that require it, otherwise an error will be shown.
+
+## Performance loss
+
+The `entity_model` acted as a filter on the amount of data to perform the
+operations, if the user doesn't specify it, the repo needs to work with more
+data and therefore be slower. Maybe some of the methods like `all`, `first`, or
+`last` will work faster on some repositories based on how they or their
+libraries work, but the `get` and `search` will definitely go slower.
+
+In the case of `get` we can mitigate it with an optional callable argument that
+can run regexps on the id to select the subset of entity models that contain
+id's of that type.
+
+# Decision
+<!-- What is the change that we're proposing and/or doing? -->
+Change the signatures of the `get`, `search`, `all`, `first` and `last` methods
+to accept one, many or no `Entity` subclasses. If none is given, it will assume
+that the repository was initialized with the `models` argument, where the user
+gives the repo the model of the data it holds.
+
+For the sake of cleanness, we're renaming `entity_models` for `models` in the
+function arguments.
+
+# Consequences
+<!-- What becomes easier or more difficult to do because of this change? -->
+The change makes the library more usable while it retains the performance of the
+previous code base.
+
+Two breaking changes were introduced though:
+
+* The argument `entity_model` is no longer the first one for the methods `get`
+    and `search`, but the second.
+* The argument `database_url` is no longer the first argument in the
+    `load_repository` function, but the second, being the first the `models`.

--- a/docs/adr/adr.md
+++ b/docs/adr/adr.md
@@ -6,14 +6,17 @@ consequences.
 graph TD
     001[001: Entity ID definition]
     002[002: Support String IDs]
+    003[003: Make entity_model optional arguments]
 
     click 001 "https://lyz-code.github.io/repository-orm/adr/001-entity_id_definition/" _blank
     click 002 "https://lyz-code.github.io/repository-orm/adr/002-support_string_ids/" _blank
+    click 003 "https://lyz-code.github.io/repository-orm/adr/003-make_entity_models_optional_arguments/" _blank
 
     001 -- Partially superseeded --> 002
 
     001:::superseeded
     002:::accepted
+    003:::accepted
 
     classDef draft fill:#CDBFEA;
     classDef proposed fill:#B1CCE8;

--- a/docs/adr/adr.md
+++ b/docs/adr/adr.md
@@ -5,10 +5,15 @@ consequences.
 ```mermaid
 graph TD
     001[001: Entity ID definition]
+    002[002: Support String IDs]
 
     click 001 "https://lyz-code.github.io/repository-orm/adr/001-entity_id_definition/" _blank
+    click 002 "https://lyz-code.github.io/repository-orm/adr/002-support_string_ids/" _blank
 
-    001:::accepted
+    001 -- Partially superseeded --> 002
+
+    001:::superseeded
+    002:::accepted
 
     classDef draft fill:#CDBFEA;
     classDef proposed fill:#B1CCE8;

--- a/docs/examples/auto_increment_id.py
+++ b/docs/examples/auto_increment_id.py
@@ -1,10 +1,11 @@
 from repository_orm import Entity, load_repository
 
-repo = load_repository()
-
 
 class Author(Entity):
     first_name: str
+
+
+repo = load_repository([Author])
 
 
 author = Author(first_name="Brandon")
@@ -14,5 +15,5 @@ repo.add(author)
 repo.commit()
 
 # Retrieve entities by their ID
-brandon = repo.get(Author, 0)
+brandon = repo.get(0)
 assert brandon == author

--- a/docs/examples/auto_increment_id.py
+++ b/docs/examples/auto_increment_id.py
@@ -1,0 +1,18 @@
+from repository_orm import Entity, load_repository
+
+repo = load_repository()
+
+
+class Author(Entity):
+    first_name: str
+
+
+author = Author(first_name="Brandon")
+
+# Add entities
+repo.add(author)
+repo.commit()
+
+# Retrieve entities by their ID
+brandon = repo.get(Author, 0)
+assert brandon == author

--- a/docs/examples/e2e_test.py
+++ b/docs/examples/e2e_test.py
@@ -6,6 +6,11 @@ from py._path.local import LocalPath
 from repository_orm import Entity, Repository, TinyDBRepository, load_repository
 
 
+# Model
+class Author(Entity):
+    first_name: str
+
+
 # Fixtures
 @pytest.fixture(name="db_tinydb")
 def db_tinydb_(tmpdir: LocalPath) -> str:
@@ -15,12 +20,7 @@ def db_tinydb_(tmpdir: LocalPath) -> str:
 
 @pytest.fixture()
 def repo(db_tinydb: str) -> TinyDBRepository:
-    return TinyDBRepository(db_tinydb)
-
-
-# Model
-class Author(Entity):
-    first_name: str
+    return TinyDBRepository([Author], db_tinydb)
 
 
 # Service
@@ -33,7 +33,7 @@ def create_greeting(repo: Repository) -> str:
 @click.command()
 @click.argument("database_url")
 def greet(database_url: str) -> None:
-    repo = load_repository(database_url)
+    repo = load_repository([Author], database_url)
 
     print(create_greeting(repo))
 

--- a/docs/examples/e2e_test.py
+++ b/docs/examples/e2e_test.py
@@ -1,0 +1,51 @@
+import click
+import pytest
+from click.testing import CliRunner
+from py._path.local import LocalPath
+
+from repository_orm import Entity, Repository, TinyDBRepository, load_repository
+
+
+# Fixtures
+@pytest.fixture(name="db_tinydb")
+def db_tinydb_(tmpdir: LocalPath) -> str:
+    tinydb_file_path = str(tmpdir.join("tinydb.db"))
+    return f"tinydb:///{tinydb_file_path}"
+
+
+@pytest.fixture()
+def repo(db_tinydb: str) -> TinyDBRepository:
+    return TinyDBRepository(db_tinydb)
+
+
+# Model
+class Author(Entity):
+    first_name: str
+
+
+# Service
+def create_greeting(repo: Repository) -> str:
+    first_author = repo.all(Author)[0]
+    return f"Hi {first_author.first_name}, you're the first author!"
+
+
+# Entrypoint
+@click.command()
+@click.argument("database_url")
+def greet(database_url: str) -> None:
+    repo = load_repository(database_url)
+
+    print(create_greeting(repo))
+
+
+# Test
+def test_greetings(repo: TinyDBRepository, db_tinydb: str) -> None:
+    author = Author(id_=20, first_name="Brandon")
+    repo.add(author)
+    repo.commit()
+    runner = CliRunner()
+
+    result = runner.invoke(greet, [db_tinydb])
+
+    assert result.exit_code == 0
+    assert result.output == "Hi Brandon, you're the first author!\n"

--- a/docs/examples/simple-example.py
+++ b/docs/examples/simple-example.py
@@ -4,7 +4,6 @@ repo = load_repository()
 
 
 class Author(Entity):
-    id_: int
     first_name: str
     last_name: str
     country: str

--- a/docs/examples/simple-example.py
+++ b/docs/examples/simple-example.py
@@ -1,7 +1,5 @@
 from repository_orm import Entity, load_repository
 
-repo = load_repository()
-
 
 class Author(Entity):
     first_name: str
@@ -9,21 +7,23 @@ class Author(Entity):
     country: str
 
 
-author = Author(id_=0, first_name="Brandon", last_name="Sanderson", country="US")
+repo = load_repository([Author])
+
+author = Author(first_name="Brandon", last_name="Sanderson", country="US")
 
 # Add entities
 repo.add(author)
 repo.commit()
 
 # Retrieve entities by their ID
-brandon = repo.get(Author, 0)
+brandon = repo.get(0)
 assert brandon == author
 
 # Search entities
-brandon = repo.search(Author, {"first_name": "Brandon"})[0]
+brandon = repo.search({"first_name": "Brandon"})[0]
 assert brandon == author
 
 # Delete entities
 repo.delete(brandon)
 repo.commit()
-assert len(repo.all(Author)) == 0
+assert len(repo.all()) == 0

--- a/docs/examples/unit_test_fake_repository.py
+++ b/docs/examples/unit_test_fake_repository.py
@@ -13,7 +13,7 @@ class Author(Entity):
 
 
 def create_greeting(repo: Repository, author_id: int) -> str:
-    author = repo.get(Author, author_id)
+    author = repo.get(author_id, Author)
     return f"Hi {author.first_name}!"
 
 

--- a/docs/examples/unit_test_fake_repository.py
+++ b/docs/examples/unit_test_fake_repository.py
@@ -1,0 +1,27 @@
+import pytest
+
+from repository_orm import Entity, FakeRepository, Repository
+
+
+@pytest.fixture()
+def repo() -> FakeRepository:
+    return FakeRepository()
+
+
+class Author(Entity):
+    first_name: str
+
+
+def create_greeting(repo: Repository, author_id: int) -> str:
+    author = repo.get(Author, author_id)
+    return f"Hi {author.first_name}!"
+
+
+def test_greetings(repo: FakeRepository) -> None:
+    author = Author(id_=20, first_name="Brandon")
+    repo.add(author)
+    repo.commit()
+
+    result = create_greeting(repo, 20)
+
+    assert result == "Hi Brandon!"

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,23 +6,37 @@ Library to ease the implementation of the [repository
 pattern](https://lyz-code.github.io/blue-book/architecture/repository_pattern/)
 in python projects.
 
+# Installing
+
+```bash
+pip install repository-orm
+```
+
+# A Simple Example
+
+```python
+{! examples/simple-example.py !} # noqa
+```
+
+# Repository pattern theory
+
 [The repository
 pattern](https://www.cosmicpython.com/book/chapter_02_repository.html) is an
-abstraction over persistent storage, allowing us to decouple our model layer
+abstraction over persistent storage, allowing you to decouple the model layer
 from the data layer. It hides the boring details of data access by pretending
 that all of our data is in memory.
 
 It has the following advantages:
 
-* We get a simple interface, which we control, between persistent storage and
+* Give a simple interface, which you control, between persistent storage and
     our domain model.
 * It's easy to make a fake version of the repository for unit testing, or to
-    swap out different storage solutions, because we've fully decoupled the
-    model from infrastructure concerns.
-* Writing the domain model before thinking about persistence helps us focus on
-    the business problem at hand. If we need to change our approach, we can do
-    that in our model, without needing to worry about foreign keys or migrations
-    until later.
+    swap out different storage solutions, because the model is fully decoupled
+    from the infrastructure.
+* Writing the domain model before thinking about persistence helps focus on
+    the problem at hand. If we need to change our approach, we can do that in
+    our model, without needing to worry about foreign keys or migrations until
+    later.
 * Our database schema is simple because we have complete control over how
     we map our object to tables.
 * Speeds up and makes more clean the business logic tests.
@@ -46,24 +60,13 @@ But the following disadvantages:
 * Supplying test classes and fixtures so extending the provided repositories is
     easy.
 
-# Installing
-
-```bash
-pip install repository-orm
-```
-
-# A Simple Example
-
-```python
-{! examples/simple-example.py !} # noqa
-```
 
 # Usage
 
-The different repositories share the following operations:
+The different repositories share the next operations:
 
 `add`
-: Add an `Entity` object to the repository, if it already exist, update the
+: Add an `Entity` object to the repository, if it already exist, it updates the
     stored attributes.
 
 `delete`
@@ -76,16 +79,19 @@ The different repositories share the following operations:
 : Persist the changes into the repository.
 
 `all`
-: Get all the entities of type `Entity` from the repository.
+: Get all the entities of a type or types from the repository. If no argument is
+given, it will return all entities.
 
 `search`
 : Get the entities whose attributes match a condition or regular expression.
 
 `first`
-: Get the first entity in the repository.
+: Get the first entity of a type or types of the repository. If no argument is
+given, it will return the first of any type of entity.
 
 `last`
-: Get the first entity in the repository.
+: Get the last entity of a type or types of the repository. If no argument is
+given, it will return the first of any type of entity.
 
 `apply_migrations`
 : Run the migrations of the repository schema.

--- a/docs/models.md
+++ b/docs/models.md
@@ -16,7 +16,17 @@ you usually need the following object types:
 # Entities
 
 We've created the [Entity][repository_orm.model.Entity] class based on the
-pydantic's `BaseModel` to enforce that they have the integer `id_` attribute,
-used for comparison and hashing of entities.
+pydantic's `BaseModel` to enforce that they have the `id_` attribute of type
+`int` or `str`, used for comparison and hashing of entities.
 
 They also have a private `_model_name` attribute with the name of the model.
+
+If you use integer IDs (which is the default), you don't need to define the
+`id_` at object creation. When you add the entity to the repository, it will
+populate it.
+
+```python
+{! examples/auto_increment_id.py !} # noqa
+```
+
+!!! warning "This won't work with `str` ids!"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -62,7 +62,7 @@ mkdocs-autolinks-plugin==0.4.0
     # via -r docs/requirements.in
 mkdocs-autorefs==0.1.1
     # via mkdocstrings
-mkdocs-git-revision-date-localized-plugin==0.9
+mkdocs-git-revision-date-localized-plugin==0.9.2
     # via -r docs/requirements.in
 mkdocs-htmlproofer-plugin==0.1.0
     # via -r docs/requirements.in

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -122,7 +122,7 @@ tornado==6.1
     #   mkdocs
 tqdm==4.60.0
     # via nltk
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   importlib-metadata
     #   pytkdocs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@
 #
 astunparse==1.6.3
     # via pytkdocs
-babel==2.9.0
+babel==2.9.1
     # via mkdocs-git-revision-date-localized-plugin
 beautifulsoup4==4.9.3
     # via mkdocs-htmlproofer-plugin
@@ -68,13 +68,13 @@ mkdocs-htmlproofer-plugin==0.1.0
     # via -r docs/requirements.in
 mkdocs-material-extensions==1.0.1
     # via mkdocs-material
-mkdocs-material==7.1.2
+mkdocs-material==7.1.3
     # via
     #   -r docs/requirements.in
     #   mkdocs-material-extensions
 mkdocs-minify-plugin==0.4.0
     # via -r docs/requirements.in
-mkdocs-section-index==0.2.3
+mkdocs-section-index==0.3.0
     # via -r docs/requirements.in
 mkdocs==1.1.2
     # via

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -30,7 +30,7 @@ htmlmin==0.1.12
     # via mkdocs-minify-plugin
 idna==2.10
     # via requests
-importlib-metadata==3.10.1
+importlib-metadata==4.0.1
     # via markdown
 jinja2==2.11.3
     # via
@@ -68,7 +68,7 @@ mkdocs-htmlproofer-plugin==0.1.0
     # via -r docs/requirements.in
 mkdocs-material-extensions==1.0.1
     # via mkdocs-material
-mkdocs-material==7.1.1
+mkdocs-material==7.1.2
     # via
     #   -r docs/requirements.in
     #   mkdocs-material-extensions
@@ -89,7 +89,7 @@ mkdocs==1.1.2
     #   mkdocstrings
 mkdocstrings==0.15.0
     # via -r docs/requirements.in
-nltk==3.6.1
+nltk==3.6.2
     # via lunr
 pygments==2.8.1
     # via mkdocs-material

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,57 @@
+Testing your code is a hated but good practice. Repository ORM tries to make
+your testing experience less cumbersome.
+
+You can use different strategies depending on the level of testing. For unit
+and integration tests the [`FakeRepository`](fake_repository.md) may be your best option, for
+end-to-end ones, I'd use [`TinyDBRepository`](tinydb_repository.md).
+
+# Unit and integration tests
+
+[Unit tests](https://en.wikipedia.org/wiki/Unit_testing) are meant to test
+individual units of code, for example, a function or a method of a class. You'll
+probably use them to test your
+[models](https://lyz-code.github.io/blue-book/architecture/domain_driven_design/#domain-modeling)
+or
+[services](https://lyz-code.github.io/blue-book/architecture/service_layer_pattern/).
+
+
+```python
+{! examples/unit_test_fake_repository.py !} # noqa
+```
+
+# End-to-end tests
+
+End-to-end tests evaluate the whole functionality of the program from the eyes
+of the user. For example, testing a command line or the API endpoint.
+Usually the program loads the repository from storage at start time, which means
+that the FakeRepository can't be used.
+
+We're going to create
+a [click](https://lyz-code.github.io/blue-book/coding/python/click/) command
+line program called `greet` that once it's called, it will return the first
+author in the repository. It's a little bit more complex but bare with me.
+
+```python
+{! examples/e2e_test.py !} # noqa
+```
+
+First we define the fixtures, we start with `db_tinydb` that uses the pytest's
+[`tmpdir`](https://lyz-code.github.io/blue-book/coding/python/pytest/#the-tmpdir-fixture)
+fixture to create a random temporal directory and then sets the database url.
+The `repo` fixture uses that database url to create a `TinyDBRepository`
+instance.
+
+The model `Author` and service `create_greeting` are similar to the previous
+section.
+
+The entrypoint is where we define the command line interface, in this case the
+command is going to be called `greet` and it's going to accept an argument
+called `database_url`, it will initialize the repository and use the
+`create_greeting` to show the message to the user through the terminal.
+
+To test this code, we first need to add an Author, so the function can look for
+it. We do it in the first three lines of `test_greetings`. Then we initialize
+the
+[`runner`](https://lyz-code.github.io/blue-book/coding/python/click/#testing-click-applications)
+which simulates a command line call, and we make sure that the program exited
+well, and gave the output we expected.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,12 +3,13 @@ site_name: Repository ORM
 site_author: Lyz
 site_url: https://lyz-code.github.io/repository-orm
 nav:
-  - Overview: index.md
+  - Repository ORM: index.md
   - Repositories:
       - FakeRepository: fake_repository.md
       - TinyDBRepository: tinydb_repository.md
       - PypikaRepository: pypika_repository.md
   - Models: models.md
+  - Testing: testing.md
   - API Reference:
       - Repository Implementations: reference_adapters.md
       - Models: reference_models.md
@@ -19,6 +20,8 @@ nav:
       - adr/adr.md
       - '001: Entity id_ definition': |
           adr/001-entity_id_definition.md
+      - '002: String id_ support': |
+          adr/002-support_string_ids.md
 
 plugins:
   - search

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,14 +14,17 @@ nav:
       - Repository Implementations: reference_adapters.md
       - Models: reference_models.md
       - Exceptions: reference_exceptions.md
-  - Create new repository: new_repo.md
-  - Contributing: contributing.md
+  - Contributing:
+      - contributing.md
+      - Create new repository: new_repo.md
   - Architecture Decision Records:
       - adr/adr.md
       - '001: Entity id_ definition': |
           adr/001-entity_id_definition.md
       - '002: String id_ support': |
           adr/002-support_string_ids.md
+      - '003: Make entity_models optional arguments': |
+          adr/003-make_entity_models_optional_arguments.md
 
 plugins:
   - search

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ exclude = '''
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-vv --tb=short"
+addopts = "-vv --tb=short -n auto"
 python_paths = "."
 norecursedirs = [
     ".tox",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ format = "grouped"
 max_line_length = 88
 show_source = true
 docstring-convention = "google"
+extended_default_ignore=[]  # Until https://github.com/flakehell/flakehell/issues/10 is solved
 
 [tool.flakehell.plugins]
 flake8-aaa = ["+*"]

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -7,6 +7,7 @@ pytest-cov
 pytest-pythonpath
 pytest-cases
 factory_boy
+pytest-xdist
 
 # Linting
 yamllint

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -471,7 +471,7 @@ typed-ast==1.4.3
     #   black
     #   flake8-annotations
     #   mypy
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   -r docs/requirements.txt
     #   -r requirements.txt
@@ -507,7 +507,7 @@ zipp==3.4.1
     #   pep517
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.1
+pip==21.1.1
     # via pip-tools
 setuptools==56.0.0
     # via

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile --allow-unsafe --output-file=requirements-dev.txt requirements-dev.in
 #
+apipkg==1.5
+    # via execnet
 appdirs==1.4.4
     # via
     #   black
@@ -85,6 +87,8 @@ entrypoints==0.3
     # via flakehell
 eradicate==2.0.0
     # via flake8-eradicate
+execnet==1.8.0
+    # via pytest-xdist
 factory-boy==3.2.0
     # via -r requirements-dev.in
 faker==8.1.2
@@ -251,7 +255,7 @@ mkdocs-autorefs==0.1.1
     # via
     #   -r docs/requirements.txt
     #   mkdocstrings
-mkdocs-git-revision-date-localized-plugin==0.9
+mkdocs-git-revision-date-localized-plugin==0.9.2
     # via
     #   -r docs/requirements.in
     #   -r docs/requirements.txt
@@ -330,7 +334,9 @@ pluggy==0.13.1
 pre-commit==2.12.1
     # via -r requirements-dev.in
 py==1.10.0
-    # via pytest
+    # via
+    #   pytest
+    #   pytest-forked
 pycodestyle==2.7.0
     # via
     #   flake8
@@ -367,13 +373,19 @@ pytest-cases==3.4.6
     # via -r requirements-dev.in
 pytest-cov==2.11.1
     # via -r requirements-dev.in
+pytest-forked==1.3.0
+    # via pytest-xdist
 pytest-pythonpath==0.7.3
+    # via -r requirements-dev.in
+pytest-xdist==2.2.1
     # via -r requirements-dev.in
 pytest==6.2.3
     # via
     #   -r requirements-dev.in
     #   pytest-cov
+    #   pytest-forked
     #   pytest-pythonpath
+    #   pytest-xdist
 python-dateutil==2.8.1
     # via faker
 pytkdocs==0.11.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ astor==0.8.1
     # via flake8-simplify
 astpretty==2.1.0
     # via flake8-expression-complexity
-astroid==2.5.3
+astroid==2.5.6
     # via pylint
 asttokens==2.0.5
     # via flake8-aaa
@@ -27,9 +27,9 @@ attrs==20.3.0
     #   pytest
 autoflake==1.4
     # via autoimport
-autoimport==0.6.1
+autoimport==0.7.0
     # via -r requirements-dev.in
-babel==2.9.0
+babel==2.9.1
     # via
     #   -r docs/requirements.txt
     #   mkdocs-git-revision-date-localized-plugin
@@ -39,7 +39,7 @@ beautifulsoup4==4.9.3
     # via
     #   -r docs/requirements.txt
     #   mkdocs-htmlproofer-plugin
-black==20.8b1
+black==21.4b2
     # via -r requirements-dev.in
 cached-property==1.5.2
     # via
@@ -71,6 +71,8 @@ coverage==5.5
     # via pytest-cov
 decopatch==1.4.8
     # via pytest-cases
+deepdiff==5.5.0
+    # via -r requirements.txt
 distlib==0.3.1
     # via virtualenv
 distro==1.5.0
@@ -85,7 +87,7 @@ eradicate==2.0.0
     # via flake8-eradicate
 factory-boy==3.2.0
     # via -r requirements-dev.in
-faker==8.1.0
+faker==8.1.2
     # via factory-boy
 filelock==3.0.12
     # via virtualenv
@@ -261,7 +263,7 @@ mkdocs-material-extensions==1.0.1
     # via
     #   -r docs/requirements.txt
     #   mkdocs-material
-mkdocs-material==7.1.2
+mkdocs-material==7.1.3
     # via
     #   -r docs/requirements.in
     #   -r docs/requirements.txt
@@ -270,7 +272,7 @@ mkdocs-minify-plugin==0.4.0
     # via
     #   -r docs/requirements.in
     #   -r docs/requirements.txt
-mkdocs-section-index==0.2.3
+mkdocs-section-index==0.3.0
     # via
     #   -r docs/requirements.in
     #   -r docs/requirements.txt
@@ -302,6 +304,10 @@ nltk==3.6.2
     #   lunr
 nodeenv==1.6.0
     # via pre-commit
+ordered-set==4.0.2
+    # via
+    #   -r requirements.txt
+    #   deepdiff
 packaging==20.9
     # via
     #   dparse
@@ -311,7 +317,7 @@ pathspec==0.8.1
     # via
     #   black
     #   yamllint
-pbr==5.5.1
+pbr==5.6.0
     # via stevedore
 pep517==0.10.0
     # via pip-tools
@@ -342,7 +348,7 @@ pygments==2.8.1
     #   -r docs/requirements.txt
     #   flakehell
     #   mkdocs-material
-pylint==2.7.4
+pylint==2.8.2
     # via -r requirements-dev.in
 pymdown-extensions==8.1.1
     # via
@@ -501,7 +507,7 @@ zipp==3.4.1
     #   pep517
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.0.1
+pip==21.1
     # via pip-tools
 setuptools==56.0.0
     # via

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ astpretty==2.1.0
     # via flake8-expression-complexity
 astroid==2.5.3
     # via pylint
-asttokens==2.0.4
+asttokens==2.0.5
     # via flake8-aaa
 astunparse==1.6.3
     # via
@@ -73,6 +73,8 @@ decopatch==1.4.8
     # via pytest-cases
 distlib==0.3.1
     # via virtualenv
+distro==1.5.0
+    # via ruyaml
 dlint==0.11.0
     # via -r requirements-dev.in
 dparse==0.5.1
@@ -87,7 +89,7 @@ faker==8.1.0
     # via factory-boy
 filelock==3.0.12
     # via virtualenv
-flake8-aaa==0.11.1
+flake8-aaa==0.11.2
     # via -r requirements-dev.in
 flake8-annotations-complexity==0.0.6
     # via -r requirements-dev.in
@@ -127,7 +129,7 @@ flake8-use-fstring==1.1
     # via -r requirements-dev.in
 flake8-variables-names==0.0.4
     # via -r requirements-dev.in
-flake8==3.9.0
+flake8==3.9.1
     # via
     #   dlint
     #   flake8-annotations
@@ -164,13 +166,13 @@ htmlmin==0.1.12
     # via
     #   -r docs/requirements.txt
     #   mkdocs-minify-plugin
-identify==2.2.3
+identify==2.2.4
     # via pre-commit
 idna==2.10
     # via
     #   -r docs/requirements.txt
     #   requests
-importlib-metadata==3.10.1
+importlib-metadata==4.0.1
     # via
     #   -r docs/requirements.txt
     #   flake8
@@ -259,7 +261,7 @@ mkdocs-material-extensions==1.0.1
     # via
     #   -r docs/requirements.txt
     #   mkdocs-material
-mkdocs-material==7.1.1
+mkdocs-material==7.1.2
     # via
     #   -r docs/requirements.in
     #   -r docs/requirements.txt
@@ -294,7 +296,7 @@ mypy-extensions==0.4.3
     #   mypy
 mypy==0.812
     # via -r requirements-dev.in
-nltk==3.6.1
+nltk==3.6.2
     # via
     #   -r docs/requirements.txt
     #   lunr
@@ -319,7 +321,7 @@ pip-tools==6.1.0
     # via -r requirements-dev.in
 pluggy==0.13.1
     # via pytest
-pre-commit==2.12.0
+pre-commit==2.12.1
     # via -r requirements-dev.in
 py==1.10.0
     # via pytest
@@ -394,9 +396,7 @@ requests==2.25.1
     #   -r docs/requirements.txt
     #   mkdocs-htmlproofer-plugin
     #   safety
-ruamel.yaml.clib==0.2.2
-    # via ruamel.yaml
-ruamel.yaml==0.17.4
+ruyaml==0.20.0
     # via yamlfix
 safety==1.10.3
     # via -r requirements-dev.in
@@ -479,7 +479,7 @@ urllib3==1.26.4
     #   -r docs/requirements.txt
     #   flakehell
     #   requests
-virtualenv==20.4.3
+virtualenv==20.4.4
     # via pre-commit
 wheel==0.36.2
     # via
@@ -488,7 +488,7 @@ wheel==0.36.2
     #   astunparse
 wrapt==1.12.1
     # via astroid
-yamlfix==0.4.1
+yamlfix==0.5.0
     # via -r requirements-dev.in
 yamllint==1.26.1
     # via -r requirements-dev.in
@@ -508,5 +508,6 @@ setuptools==56.0.0
     #   flake8-annotations-complexity
     #   flake8-expression-complexity
     #   flake8-variables-names
+    #   ruyaml
     #   safety
     #   yamllint

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile --allow-unsafe
 #
+deepdiff==5.5.0
+    # via repository-orm (setup.py)
+ordered-set==4.0.2
+    # via deepdiff
 pydantic==1.8.1
     # via repository-orm (setup.py)
 pymysql==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ tinydb==4.4.0
     # via
     #   repository-orm (setup.py)
     #   tinydb-serialization
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via pydantic
 yoyo-migrations==7.3.1
     # via repository-orm (setup.py)

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         "Natural Language :: English",
     ],
     install_requires=[
+        "deepdiff",
         "pydantic",
         "pypika",
         "pymysql",

--- a/setup.py
+++ b/setup.py
@@ -3,30 +3,8 @@
 import re
 from glob import glob
 from os.path import basename, splitext
-from subprocess import getoutput
 
 from setuptools import find_packages, setup
-from setuptools.command.install import install
-
-
-# To remove when the PR is merged:
-# * PostInstall
-# * In build.yml pipeline
-# * Add the requirement in setup.py
-# * In Makefile
-# ignore: cannot subclass install, has type Any. And what would you do?
-class PostInstall(install):  # type: ignore
-    """Install direct dependency.
-
-    Pypi doesn't allow uploading packages with direct dependencies, so we need to
-    install them manually.
-    """
-
-    def run(self) -> None:
-        """Install dependencies."""
-        install.run(self)
-        print(getoutput("pip install git+git://github.com/lyz-code/deepdiff@master"))
-
 
 # Avoid loading the package to extract the version
 with open("src/repository_orm/version.py") as fp:
@@ -46,7 +24,6 @@ setup(
         "Library to ease the implementation of the repository pattern in "
         "Python projects."
     ),
-    cmdclass={"install": PostInstall},
     author="Lyz",
     author_email="lyz-code-security-advisories@riseup.net",
     license="GNU General Public License v3",

--- a/src/repository_orm/__init__.py
+++ b/src/repository_orm/__init__.py
@@ -1,4 +1,4 @@
-"""Library to ease the implementation of the repository pattern in Python projects.."""
+"""Library to ease the implementation of the repository pattern in Python projects."""
 
 from .adapters import (
     AbstractRepository,
@@ -8,13 +8,15 @@ from .adapters import (
     Repository,
     TinyDBRepository,
 )
-from .exceptions import EntityNotFoundError
-from .model import Entity
+from .exceptions import AutoIncrementError, EntityNotFoundError
+from .model import Entity, EntityID
 from .services import load_repository
 
 __all__ = [
     "AbstractRepository",
+    "AutoIncrementError",
     "Entity",
+    "EntityID",
     "EntityNotFoundError",
     "FakeRepository",
     "FakeRepositoryDB",

--- a/src/repository_orm/__init__.py
+++ b/src/repository_orm/__init__.py
@@ -1,9 +1,11 @@
 """Library to ease the implementation of the repository pattern in Python projects."""
 
 from .adapters import (
-    AbstractRepository,
     FakeRepository,
     FakeRepositoryDB,
+    Models,
+    OptionalModelOrModels,
+    OptionalModels,
     PypikaRepository,
     Repository,
     TinyDBRepository,
@@ -13,15 +15,18 @@ from .model import Entity, EntityID
 from .services import load_repository
 
 __all__ = [
-    "AbstractRepository",
     "AutoIncrementError",
     "Entity",
     "EntityID",
     "EntityNotFoundError",
     "FakeRepository",
     "FakeRepositoryDB",
+    "Models",
+    "OptionalModels",
+    "OptionalModelOrModels",
     "PypikaRepository",
-    "TinyDBRepository",
     "Repository",
+    "Repository",
+    "TinyDBRepository",
     "load_repository",
 ]

--- a/src/repository_orm/adapters/__init__.py
+++ b/src/repository_orm/adapters/__init__.py
@@ -9,21 +9,21 @@ References:
 """
 
 import logging
-from typing import TypeVar
 
-from .abstract import AbstractRepository
+from .abstract import Models, OptionalModelOrModels, OptionalModels, Repository
 from .fake import FakeRepository, FakeRepositoryDB
 from .pypika import PypikaRepository
 from .tinydb import TinyDBRepository
 
 log = logging.getLogger(__name__)
 
-Repository = TypeVar("Repository", PypikaRepository, FakeRepository, TinyDBRepository)
-
 __all__ = [
-    "AbstractRepository",
+    "Repository",
     "PypikaRepository",
     "FakeRepository",
     "FakeRepositoryDB",
+    "Models",
+    "OptionalModels",
+    "OptionalModelOrModels",
     "TinyDBRepository",
 ]

--- a/src/repository_orm/adapters/abstract.py
+++ b/src/repository_orm/adapters/abstract.py
@@ -1,16 +1,21 @@
 """Define the interface of the repositories."""
 
 import abc
-from typing import Dict, List, Type, TypeVar
+from typing import Dict, List, Optional, Type, TypeVar, Union
 
 from ..exceptions import AutoIncrementError, EntityNotFoundError
 from ..model import Entity as EntityModel
 from ..model import EntityID
 
+# no cover: The lines with the flag are being tested by it's subclasses.
+
 Entity = TypeVar("Entity", bound=EntityModel)
+Models = List[Type[Entity]]
+OptionalModels = Optional[Models[Entity]]
+OptionalModelOrModels = Optional[Union[Type[Entity], Models[Entity]]]
 
 
-class AbstractRepository(abc.ABC):
+class Repository(abc.ABC):
     """Gather common methods and define the interface of the repositories.
 
     Attributes:
@@ -18,13 +23,19 @@ class AbstractRepository(abc.ABC):
     """
 
     @abc.abstractmethod
-    def __init__(self, database_url: str = "") -> None:
+    def __init__(
+        self, models: OptionalModels[Entity] = None, database_url: str = ""
+    ) -> None:
         """Initialize the repository attributes.
 
         Args:
             database_url: URL specifying the connection to the database.
+            models: List of stored entity models.
         """
         self.database_url = database_url
+        if models is None:
+            models = []
+        self.models = models
 
     @abc.abstractmethod
     def add(self, entity: Entity) -> None:
@@ -48,33 +59,30 @@ class AbstractRepository(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get(self, entity_model: Type[Entity], entity_id: EntityID) -> Entity:
+    def get(
+        self, id_: EntityID, models: OptionalModelOrModels[Entity] = None
+    ) -> Entity:
         """Obtain an entity from the repository by it's ID.
 
         Args:
-            entity_model: Type of entity object to obtain.
-            entity_id: ID of the entity object to obtain.
+            models: Entity class or classes to obtain.
+            id_: ID of the entity to obtain.
 
         Returns:
-            entity: Entity object that matches the search criteria.
+            entity: Entity object that matches the id_
 
         Raises:
             EntityNotFoundError: If the entity is not found.
+            TooManyEntitiesError: If more than one entity was found.
         """
         raise NotImplementedError
 
     @abc.abstractmethod
-    def all(self, entity_model: Type[Entity]) -> List[Entity]:
-        """Obtain all the entities of a type from the repository.
+    def all(self, models: OptionalModelOrModels[Entity] = None) -> List[Entity]:
+        """Get all the entities from the repository whose class is included in models.
 
         Args:
-            entity_model: Type of entity objects to obtain.
-
-        Returns:
-            entities: List of Entity object that matches the search criteria.
-
-        Raises:
-            EntityNotFoundError: If the entities are not found.
+            models: Entity class or classes to obtain.
         """
         raise NotImplementedError
 
@@ -85,12 +93,14 @@ class AbstractRepository(abc.ABC):
 
     @abc.abstractmethod
     def search(
-        self, entity_model: Type[Entity], fields: Dict[str, EntityID]
+        self,
+        fields: Dict[str, EntityID],
+        models: OptionalModelOrModels[Entity] = None,
     ) -> List[Entity]:
-        """Obtain the entities whose attributes match one or several conditions.
+        """Get the entities whose attributes match one or several conditions.
 
         Args:
-            entity_model: Type of entity object to obtain.
+            models: Entity class or classes to obtain.
             fields: Dictionary with the {key}:{value} to search.
 
         Returns:
@@ -111,47 +121,42 @@ class AbstractRepository(abc.ABC):
         """
         raise NotImplementedError
 
-    @abc.abstractmethod
-    def last(self, entity_model: Type[Entity], index: bool = True) -> Entity:
+    def last(self, models: OptionalModelOrModels[Entity] = None) -> Entity:
         """Get the biggest entity from the repository.
 
         Args:
-            entity_model: Type of entity object to obtain.
-            index: Check only commited entities.
+            models: Entity class or classes to obtain.
 
         Returns:
-            entity: Biggest Entity object of type entity_model.
+            entity: Biggest Entity object of type models.
 
         Raises:
             EntityNotFoundError: If there are no entities.
         """
         try:
-            return max(self.all(entity_model))
-        except KeyError as error:
+            return max(self.all(models))
+        except ValueError as error:
             # no cover: it's tested by it's subclasses
-            raise EntityNotFoundError(  # pragma: no cover
-                f"There are no {entity_model.__name__}s in the repository."
-            ) from error
+            models = self._build_models(models)  # pragma: nocover
+            raise self._model_not_found(models) from error  # pragma: nocover
 
-    def first(self, entity_model: Type[Entity]) -> Entity:
+    def first(self, models: OptionalModelOrModels[Entity]) -> Entity:
         """Get the smallest entity from the repository.
 
         Args:
-            entity_model: Type of entity object to obtain.
+            models: Type of entity object to obtain.
 
         Returns:
-            entity: Smallest Entity object of type entity_model.
+            entity: Smallest Entity object of type models.
 
         Raises:
             EntityNotFoundError: If there are no entities.
         """
         try:
-            return min(self.all(entity_model))
-        except KeyError as error:
-            # no cover: it's tested by it's subclasses
-            raise EntityNotFoundError(  # pragma: no cover
-                f"There are no {entity_model.__name__}s in the repository."
-            ) from error
+            return min(self.all(models))
+        except ValueError as error:
+            models = self._build_models(models)  # pragma: nocover
+            raise self._model_not_found(models) from error  # pragma: nocover
 
     def _next_id(self, entity: Entity) -> int:
         """Return one id unit more than the last entity id in the repository index.
@@ -160,7 +165,7 @@ class AbstractRepository(abc.ABC):
             entity: Entity whose model we want to get the next entity id.
         """
         try:
-            last_id = self.last(type(entity), index=False).id_
+            last_id = self.last(type(entity)).id_
         except EntityNotFoundError:
             return 0
         if isinstance(last_id, int):
@@ -170,3 +175,38 @@ class AbstractRepository(abc.ABC):
             "Please set the id_ yourself before adding the entities to the "
             "repository."
         )
+
+    def _model_not_found(
+        self, models: Models[Entity], append_str: str = ""
+    ) -> EntityNotFoundError:
+        """Raise the appropriate EntityNotFoundError exception based on models.
+
+        Args:
+            models: Type of entity object to obtain.
+            append_str: message to append after the message of no entities found.
+                Must start with a space
+
+        Raises:
+            EntityNotFoundError
+        """
+        if models == self.models:
+            return EntityNotFoundError(  # pragma: no cover
+                f"There are no entities in the repository{append_str}."
+            )
+        if len(models) > 0:
+            entity_str = ", ".join([model.__name__ for model in models])
+            return EntityNotFoundError(  # pragma: no cover
+                f"There are no entities of type {entity_str} "
+                f"in the repository{append_str}."
+            )
+        return EntityNotFoundError(  # pragma: no cover
+            f"There are no {models[0].__name__}s in the repository{append_str}."
+        )
+
+    def _build_models(self, models: OptionalModelOrModels[Entity]) -> Models[Entity]:
+        """Create the Models from the OptionalModelOrModels."""
+        if models is None:
+            models = self.models
+        elif not isinstance(models, list):
+            models = [models]
+        return models

--- a/src/repository_orm/adapters/fake.py
+++ b/src/repository_orm/adapters/fake.py
@@ -1,38 +1,31 @@
 """Store the fake repository implementation."""
 
 import copy
-import logging
 import re
-from typing import Any, Dict, List, Type, TypeVar
+from contextlib import suppress
+from typing import Dict, List, Type
 
 from deepdiff import extract, grep
 
-# [Pydantic issue](https://github.com/samuelcolvin/pydantic/issues/1961)
-from pydantic import BaseModel, Field  # pylint: disable=no-name-in-module
-
-from ..exceptions import EntityNotFoundError
-from ..model import Entity as EntityModel
+from ..exceptions import EntityNotFoundError, TooManyEntitiesError
 from ..model import EntityID
-from .abstract import AbstractRepository
-
-log = logging.getLogger(__name__)
-
-Entity = TypeVar("Entity", bound=EntityModel)
+from .abstract import Entity, Models, OptionalModelOrModels, OptionalModels, Repository
 
 FakeRepositoryDB = Dict[Type[Entity], Dict[EntityID, Entity]]
 
 
-class FakeRepository(BaseModel, AbstractRepository):
+class FakeRepository(Repository):
     """Implement the repository pattern using a memory dictionary."""
 
-    entities: FakeRepositoryDB[Any] = Field(default_factory=dict)
-    new_entities: FakeRepositoryDB[Any] = Field(default_factory=dict)
-
-    def __init__(self, database_url: str = "", **data: Any) -> None:
+    def __init__(
+        self, models: OptionalModels[Entity] = None, database_url: str = ""
+    ) -> None:
         """Initialize the repository attributes."""
-        super().__init__(**data)
+        super().__init__(models=models)
         if database_url == "/inexistent_dir/database.db":
             raise ConnectionError(f"Could not create database file: {database_url}")
+        self.entities: FakeRepositoryDB[Entity] = {}
+        self.new_entities: FakeRepositoryDB[Entity] = {}
 
     def add(self, entity: Entity) -> None:
         """Append an entity to the repository.
@@ -69,63 +62,70 @@ class FakeRepository(BaseModel, AbstractRepository):
                 f"Unable to delete entity {entity} because it's not in the repository"
             ) from error
 
-    def get(self, entity_model: Type[Entity], entity_id: EntityID) -> Entity:
+    def get(
+        self, id_: EntityID, models: OptionalModelOrModels[Entity] = None
+    ) -> Entity:
         """Obtain an entity from the repository by it's ID.
 
         Args:
-            entity_model: Type of entity object to obtain.
-            entity_id: ID of the entity object to obtain.
+            models: Entity class or classes to obtain.
+            id_: ID of the entity to obtain.
 
         Returns:
-            entity: Entity object that matches the search criteria.
+            entity: Entity object that matches the id_
 
         Raises:
             EntityNotFoundError: If the entity is not found.
+            TooManyEntitiesError: If more than one entity was found.
         """
-        try:
-            entity = self.entities[entity_model][entity_id]
-        except KeyError as error:
-            raise EntityNotFoundError(
-                f"There are no {entity_model.__name__}s "
-                f"with id {entity_id} in the repository."
-            ) from error
+        matching_entities = []
+        models = self._build_models(models)
 
-        return entity
+        for model in models:
+            with suppress(KeyError):
+                matching_entities.append(self.entities[model][id_])
 
-    def all(self, entity_model: Type[Entity]) -> List[Entity]:
-        """Obtain all the entities of a type from the repository.
+        if len(matching_entities) == 1:
+            return matching_entities[0]
+        elif len(matching_entities) == 0:
+            raise self._model_not_found(models, f" with id {id_}")
+        else:
+            raise TooManyEntitiesError(
+                f"More than one entity was found with the id {id_}"
+            )
+
+    def all(self, models: OptionalModelOrModels[Entity] = None) -> List[Entity]:
+        """Get all the entities from the repository whose class is included in models.
 
         Args:
-            entity_model: Type of entity objects to obtain.
-
-        Returns:
-            entities: List of Entity object that matches the search criteria.
-
-        Raises:
-            EntityNotFoundError: If the entities are not found.
+            models: Entity class or classes to obtain.
         """
-        try:
-            return sorted(
-                entity for entity_id, entity in self.entities[entity_model].items()
-            )
-        except KeyError as error:
-            raise EntityNotFoundError(
-                f"There are no {entity_model.__name__} entities in the repository"
-            ) from error
+        entities = []
+        models = self._build_models(models)
+
+        for model in models:
+            with suppress(KeyError):
+                entities += sorted(
+                    entity for entity_id, entity in self.entities[model].items()
+                )
+
+        return entities
 
     def commit(self) -> None:
         """Persist the changes into the repository."""
-        for entity_model, entities in self.new_entities.items():
-            self.entities[entity_model] = entities
+        for model, entities in self.new_entities.items():
+            self.entities[model] = entities
         self.new_entities = {}
 
     def search(
-        self, entity_model: Type[Entity], fields: Dict[str, EntityID]
+        self,
+        fields: Dict[str, EntityID],
+        models: OptionalModelOrModels[Entity] = None,
     ) -> List[Entity]:
-        """Obtain the entities whose attributes match one or several conditions.
+        """Get the entities whose attributes match one or several conditions.
 
         Args:
-            entity_model: Type of entity object to obtain.
+            models: Entity class or classes to obtain.
             fields: Dictionary with the {key}:{value} to search.
 
         Returns:
@@ -134,13 +134,10 @@ class FakeRepository(BaseModel, AbstractRepository):
         Raises:
             EntityNotFoundError: If the entities are not found.
         """
-        all_entities = self.all(entity_model)
+        models = self._build_models(models)
+        all_entities: List[Entity] = self.all(models)
         entities_dict = {entity.id_: entity for entity in all_entities}
         entity_attributes = {entity.id_: entity.dict() for entity in all_entities}
-        error_msg = (
-            f"There are no {entity_model.__name__}s that match "
-            f"the search filter {fields}"
-        )
 
         for key, value in fields.items():
             # Get entities that have the value `value`
@@ -152,7 +149,9 @@ class FakeRepository(BaseModel, AbstractRepository):
             try:
                 entities_with_value["matched_values"]
             except KeyError as error:
-                raise EntityNotFoundError(error_msg) from error
+                raise self._model_not_found(
+                    models, f" that match the search filter {fields}"
+                ) from error
 
             for path in entities_with_value["matched_values"]:
                 entity_id = re.sub(r"root\[(.*?)\]\[.*", r"\1", path)
@@ -165,11 +164,10 @@ class FakeRepository(BaseModel, AbstractRepository):
 
                 # Add the entity to the matching ones only if the value is of the
                 # attribute `key`.
-                if re.match(re.compile(fr"root\['?{entity_id}'?\]\['{key}'\]"), path):
+                if re.match(fr"root\['?{entity_id}'?\]\['{key}'\]", path):
                     matching_entity_attributes[entity_id] = extract(
                         entity_attributes, f"root[{entity_id}]"
                     )
-
             entity_attributes = matching_entity_attributes
         entities = [entities_dict[key] for key in entity_attributes.keys()]
 
@@ -184,45 +182,49 @@ class FakeRepository(BaseModel, AbstractRepository):
         """
         # The fake repository doesn't have any schema
 
-    def last(self, entity_model: Type[Entity], index: bool = True) -> Entity:
-        """Get the greatest entity from the repository.
+    def last(self, models: OptionalModelOrModels[Entity] = None) -> Entity:
+        """Get the biggest entity from the repository.
 
         Args:
-            entity_model: Type of entity object to obtain.
-            index: Check only commited entities.
+            models: Entity class or classes to obtain.
 
         Returns:
-            entity: Entity object that matches the search criteria.
+            entity: Biggest Entity object of type models.
 
         Raises:
             EntityNotFoundError: If there are no entities.
         """
         try:
-            last_index_entity = super().last(entity_model)
+            last_index_entity: Entity = super().last(models)
         except EntityNotFoundError as empty_repo:
-            if not index:
-                try:
-                    # Empty repo but entities staged to be commited.
-                    return max(
-                        [
-                            entity
-                            for _, entity in self.new_entities[entity_model].items()
-                        ]
-                    )
-                except KeyError as no_staged_entities:
-                    # Empty repo and no entities staged.
-                    raise empty_repo from no_staged_entities
-            raise empty_repo
+            models = self._build_models(models)
+            try:
+                # Empty repo but entities staged to be commited.
+                return max(self._staged_entities(models))
+            except KeyError as no_staged_entities:
+                # Empty repo and no entities staged.
+                raise empty_repo from no_staged_entities
 
-        if index:
-            return last_index_entity
         try:
-            last_staged_entity = max(
-                [entity for _, entity in self.new_entities[entity_model].items()]
-            )
+            models = self._build_models(models)
+            last_staged_entity: Entity = max(self._staged_entities(models))
         except KeyError:
             # Full repo and no staged entities.
             return last_index_entity
 
         # Full repo and staged entities.
         return max([last_index_entity, last_staged_entity])
+
+    def _staged_entities(self, models: Models[Entity]) -> List[Entity]:
+        """Return a list of staged entities of type models.
+
+        Args:
+            models: Return only instances of these models.
+        """
+        staged_entities = []
+
+        for model in models:
+            staged_entities += [
+                entity for _, entity in self.new_entities[model].items()
+            ]
+        return staged_entities

--- a/src/repository_orm/adapters/pypika.py
+++ b/src/repository_orm/adapters/pypika.py
@@ -4,20 +4,18 @@ import logging
 import os
 import re
 import sqlite3
+from contextlib import suppress
 from sqlite3 import OperationalError
-from typing import Dict, List, Type, TypeVar, Union
+from typing import Dict, List, Type, Union
 
 from pypika import Query, Table
 from yoyo import get_backend, read_migrations
 
-from ..exceptions import EntityNotFoundError
-from ..model import Entity as EntityModel
+from ..exceptions import EntityNotFoundError, TooManyEntitiesError
 from ..model import EntityID
-from .abstract import AbstractRepository
+from .abstract import Entity, OptionalModelOrModels, OptionalModels, Repository
 
 log = logging.getLogger(__name__)
-
-Entity = TypeVar("Entity", bound=EntityModel)
 
 
 def _regexp(expression: str, item: str) -> bool:
@@ -34,12 +32,19 @@ def _regexp(expression: str, item: str) -> bool:
     return reg.search(item) is not None
 
 
-class PypikaRepository(AbstractRepository):
+class PypikaRepository(Repository):
     """Implement the repository pattern using the Pypika query builder."""
 
-    def __init__(self, database_url: str) -> None:
-        """Initialize the repository attributes."""
-        super().__init__(database_url)
+    def __init__(
+        self, models: OptionalModels[Entity] = None, database_url: str = ""
+    ) -> None:
+        """Initialize the repository attributes.
+
+        Args:
+            database_url: URL specifying the connection to the database.
+            models: List of stored entity models.
+        """
+        super().__init__(models, database_url)
         database_file = database_url.replace("sqlite:///", "")
         if not os.path.isfile(database_file):
             try:
@@ -67,9 +72,9 @@ class PypikaRepository(AbstractRepository):
         return Table(entity._model_name.lower())
 
     @staticmethod
-    def _table_model(entity_model: Type[Entity]) -> Table:
+    def _table_model(model: Type[Entity]) -> Table:
         """Return the table of the selected entity class."""
-        return Table(entity_model.__name__.lower())
+        return Table(model.__name__.lower())
 
     def add(self, entity: Entity) -> None:
         """Append an entity to the repository.
@@ -110,7 +115,7 @@ class PypikaRepository(AbstractRepository):
         """
         table = self._table(entity)
         try:
-            self.get(type(entity), entity.id_)
+            self.get(entity.id_, type(entity))
         except EntityNotFoundError as error:
             raise EntityNotFoundError(
                 f"Unable to delete entity {entity} because it's not in the repository"
@@ -118,58 +123,60 @@ class PypikaRepository(AbstractRepository):
         query = Query.from_(table).delete().where(table.id == entity.id_)
         self._execute(query)
 
-    def get(self, entity_model: Type[Entity], entity_id: EntityID) -> Entity:
+    def get(
+        self, id_: EntityID, models: OptionalModelOrModels[Entity] = None
+    ) -> Entity:
         """Obtain an entity from the repository by it's ID.
 
         Args:
-            entity_model: Type of entity object to obtain.
-            entity_id: ID of the entity object to obtain.
+            models: Entity class or classes to obtain.
+            id_: ID of the entity to obtain.
 
         Returns:
-            entity: Entity object that matches the search criteria.
+            entity: Entity object that matches the id_
 
         Raises:
             EntityNotFoundError: If the entity is not found.
+            TooManyEntitiesError: If more than one entity was found.
         """
-        table = self._table_model(entity_model)
-        query = Query.from_(table).select("*").where(table.id == entity_id)
+        matching_entities = []
+        models = self._build_models(models)
 
-        try:
-            return self._build_entities(entity_model, query)[0]
-        except IndexError as error:
-            raise EntityNotFoundError(
-                f"There are no {entity_model.__name__}s with id {entity_id} in the"
-                " repository."
-            ) from error
+        for model in models:
+            table = self._table_model(model)
+            query = Query.from_(table).select("*").where(table.id == id_)
+            matching_entities += self._build_entities(model, query)
 
-    def all(self, entity_model: Type[Entity]) -> List[Entity]:
-        """Obtain all the entities of a type from the repository.
+        if len(matching_entities) == 1:
+            return matching_entities[0]
+        elif len(matching_entities) == 0:
+            raise self._model_not_found(models, f" with id {id_}")
+        else:
+            raise TooManyEntitiesError(
+                f"More than one entity was found with the id {id_}"
+            )
+
+    def all(self, models: OptionalModelOrModels[Entity] = None) -> List[Entity]:
+        """Get all the entities from the repository whose class is included in models.
 
         Args:
-            entity_model: Type of entity objects to obtain.
-
-        Returns:
-            entities: List of Entity object that matches the search criteria.
-
-        Raises:
-            EntityNotFoundError: If the entities are not found.
+            models: Entity class or classes to obtain.
         """
-        table = self._table_model(entity_model)
-        query = Query.from_(table).select("*")
+        entities = []
+        models = self._build_models(models)
 
-        entities = self._build_entities(entity_model, query)
-        if len(entities) == 0:
-            raise EntityNotFoundError(
-                f"There are no {entity_model.__name__} entities in the repository"
-            )
+        for model in models:
+            table = self._table_model(model)
+            query = Query.from_(table).select("*")
+            entities += self._build_entities(model, query)
 
         return entities
 
-    def _build_entities(self, entity_model: Type[Entity], query: Query) -> List[Entity]:
+    def _build_entities(self, model: Type[Entity], query: Query) -> List[Entity]:
         """Build Entity objects from the data extracted from the database.
 
         Args:
-            entity_model: The model of the entity to build
+            models: The model of the entity to build
             query: pypika query of the entities you want to build
         """
         cursor = self._execute(query)
@@ -185,7 +192,7 @@ class PypikaRepository(AbstractRepository):
             }
             entity_dict["id_"] = entity_dict.pop("id")
 
-            entities.append(entity_model(**entity_dict))
+            entities.append(model(**entity_dict))
         return entities
 
     def commit(self) -> None:
@@ -193,12 +200,14 @@ class PypikaRepository(AbstractRepository):
         self.connection.commit()
 
     def search(
-        self, entity_model: Type[Entity], fields: Dict[str, EntityID]
+        self,
+        fields: Dict[str, EntityID],
+        models: OptionalModelOrModels[Entity] = None,
     ) -> List[Entity]:
-        """Obtain the entities whose attributes match one or several conditions.
+        """Get the entities whose attributes match one or several conditions.
 
         Args:
-            entity_model: Type of entity object to obtain.
+            models: Entity class or classes to obtain.
             fields: Dictionary with the {key}:{value} to search.
 
         Returns:
@@ -207,29 +216,27 @@ class PypikaRepository(AbstractRepository):
         Raises:
             EntityNotFoundError: If the entities are not found.
         """
-        table = self._table_model(entity_model)
-        query = Query.from_(table).select("*")
+        entities: List[Entity] = []
+        models = self._build_models(models)
 
-        for key, value in fields.items():
-            if key == "id_":
-                key = "id"
-            if isinstance(value, str):
-                query = query.where(getattr(table, key).regexp(value))
-            else:
-                query = query.where(getattr(table, key) == value)
+        for model in models:
+            table = self._table_model(model)
+            query = Query.from_(table).select("*")
 
-        try:
-            entities = self._build_entities(entity_model, query)
-        except OperationalError as error:
-            raise EntityNotFoundError(
-                f"There are no {entity_model.__name__}s that match the search filter"
-                f" {fields}"
-            ) from error
+            for key, value in fields.items():
+                if key == "id_":
+                    key = "id"
+                if isinstance(value, str):
+                    query = query.where(getattr(table, key).regexp(value))
+                else:
+                    query = query.where(getattr(table, key) == value)
+
+            with suppress(OperationalError):
+                entities += self._build_entities(model, query)
 
         if len(entities) == 0:
-            raise EntityNotFoundError(
-                f"There are no {entity_model.__name__}s that match the search filter"
-                f" {fields}"
+            raise self._model_not_found(
+                models, f" that match the search filter {fields}"
             )
 
         return entities
@@ -264,18 +271,3 @@ class PypikaRepository(AbstractRepository):
                     log.error(error)
                     raise error
             log.debug("Complete running database migrations")
-
-    def last(self, entity_model: Type[Entity], index: bool = True) -> Entity:
-        """Get the greatest entity from the repository.
-
-        Args:
-            entity_model: Type of entity object to obtain.
-            index: Check only commited entities.
-
-        Returns:
-            entity: Entity object that matches the search criteria.
-
-        Raises:
-            EntityNotFoundError: If there are no entities.
-        """
-        return super().last(entity_model)

--- a/src/repository_orm/adapters/tinydb.py
+++ b/src/repository_orm/adapters/tinydb.py
@@ -1,35 +1,35 @@
 """Define the TinyDB Repository."""
 
-import logging
 import os
-from typing import Any, Dict, List, Type, TypeVar
+from typing import Any, Dict, List
 
 from tinydb import Query, TinyDB
+from tinydb.queries import QueryInstance
 from tinydb.storages import JSONStorage
 from tinydb_serialization import SerializationMiddleware
 from tinydb_serialization.serializers import DateTimeSerializer
 
+from repository_orm.exceptions import TooManyEntitiesError
+
 from ..exceptions import EntityNotFoundError
-from ..model import Entity as EntityModel
 from ..model import EntityID
-from .abstract import AbstractRepository
-
-log = logging.getLogger(__name__)
-
-Entity = TypeVar("Entity", bound=EntityModel)
+from .abstract import Entity, Models, OptionalModelOrModels, OptionalModels, Repository
 
 
-class TinyDBRepository(AbstractRepository):
+class TinyDBRepository(Repository):
     """Implement the repository pattern using the TinyDB."""
 
-    def __init__(self, database_url: str) -> None:
+    def __init__(
+        self, models: OptionalModels[Entity] = None, database_url: str = ""
+    ) -> None:
         """Initialize the repository attributes.
 
-        Attributes:
+        Args:
             database_url: URL specifying the connection to the database.
+            models: List of stored entity models.
         """
-        super().__init__(database_url)
-        self.database_file = database_url.replace("tinydb:///", "")
+        super().__init__(models, database_url)
+        self.database_file = os.path.expanduser(database_url.replace("tinydb://", ""))
         if not os.path.isfile(self.database_file):
             try:
                 with open(self.database_file, "a") as file_cursor:
@@ -64,80 +64,86 @@ class TinyDBRepository(AbstractRepository):
             entity: Entity to remove from the repository.
         """
         try:
-            self.get(type(entity), entity.id_)
+            self.get(entity.id_, type(entity))
         except EntityNotFoundError as error:
             raise EntityNotFoundError(
                 f"Unable to delete entity {entity} because it's not in the repository"
             ) from error
         self.staged["remove"].append(entity)
 
-    def get(self, entity_model: Type[Entity], entity_id: EntityID) -> Entity:
+    def get(
+        self, id_: EntityID, models: OptionalModelOrModels[Entity] = None
+    ) -> Entity:
         """Obtain an entity from the repository by it's ID.
 
         Args:
-            entity_model: Type of entity object to obtain.
-            entity_id: ID of the entity object to obtain.
+            models: Entity class or classes to obtain.
+            id_: ID of the entity to obtain.
 
         Returns:
-            entity: Entity object that matches the search criteria.
+            entity: Entity object that matches the id_
 
         Raises:
             EntityNotFoundError: If the entity is not found.
+            TooManyEntitiesError: If more than one entity was found.
         """
-        try:
-            entity_data = self.db_.search(
-                (Query().id_ == entity_id)
-                & (Query().model_type_ == entity_model.__name__.lower())
-            )[0]
-        except IndexError as error:
-            raise EntityNotFoundError(
-                f"There are no {entity_model.__name__}s with id {entity_id} in the"
-                " repository."
-            ) from error
+        models = self._build_models(models)
+        model_query = self._build_model_query(models)
 
-        return self._build_entity(entity_data, entity_model)
+        matching_entities_data = self.db_.search((Query().id_ == id_) & (model_query))
 
-    @staticmethod
+        if len(matching_entities_data) == 1:
+            return self._build_entity(matching_entities_data[0], models)
+        elif len(matching_entities_data) == 0:
+            raise self._model_not_found(models, f" with id {id_}")
+        else:
+            raise TooManyEntitiesError(
+                f"More than one entity was found with the id {id_}"
+            )
+
     def _build_entity(
-        entity_data: Dict[Any, Any], entity_model: Type[Entity]
+        self,
+        entity_data: Dict[Any, Any],
+        models: OptionalModelOrModels[Entity] = None,
     ) -> Entity:
         """Create an entity from the data stored in a row of the database.
 
         Args:
             entity_data: Dictionary with the attributes of the entity.
-            entity_model: Type of entity object to obtain.
+            models: Type of entity object to obtain.
 
         Returns:
             entity: Built Entity.
         """
-        entity_data.pop("model_type_")
+        # If we don't copy the data, the all method stops being idempotent.
+        entity_data = entity_data.copy()
+        model_name = entity_data.pop("model_type_")
+        models = self._build_models(models)
 
-        return entity_model.parse_obj(entity_data)
+        for model in models:
+            if model.schema()["title"].lower() == model_name:
+                model = model
+                break
+        return model.parse_obj(entity_data)
 
-    def all(self, entity_model: Type[Entity]) -> List[Entity]:
-        """Obtain all the entities of a type from the repository.
+    def all(self, models: OptionalModelOrModels[Entity] = None) -> List[Entity]:
+        """Get all the entities from the repository whose class is included in models.
 
         Args:
-            entity_model: Type of entity objects to obtain.
-
-        Returns:
-            entities: List of Entity object that matches the search criteria.
-
-        Raises:
-            EntityNotFoundError: If the entities are not found.
+            models: Entity class or classes to obtain.
         """
-        entities = []
-        entities_data = self.db_.search(
-            Query().model_type_ == entity_model.__name__.lower()
-        )
+        entities: List[Entity] = []
+        models = self._build_models(models)
+
+        if models == self.models:
+            entities_data = self.db_.all()
+        else:
+            query = self._build_model_query(models)
+            entities_data = self.db_.search(query)
 
         for entity_data in entities_data:
-            entities.append(self._build_entity(entity_data, entity_model))
+            entities.append(self._build_entity(entity_data))
 
-        if len(entities) == 0:
-            raise EntityNotFoundError(
-                f"There are no {entity_model.__name__} entities in the repository"
-            )
         return entities
 
     @staticmethod
@@ -173,12 +179,14 @@ class TinyDBRepository(AbstractRepository):
         self.staged["remove"].clear()
 
     def search(
-        self, entity_model: Type[Entity], fields: Dict[str, EntityID]
+        self,
+        fields: Dict[str, EntityID],
+        models: OptionalModelOrModels[Entity] = None,
     ) -> List[Entity]:
-        """Obtain the entities whose attributes match one or several conditions.
+        """Get the entities whose attributes match one or several conditions.
 
         Args:
-            entity_model: Type of entity object to obtain.
+            models: Entity class or classes to obtain.
             fields: Dictionary with the {key}:{value} to search.
 
         Returns:
@@ -187,26 +195,72 @@ class TinyDBRepository(AbstractRepository):
         Raises:
             EntityNotFoundError: If the entities are not found.
         """
-        entities = []
+        entities: List[Entity] = []
+        models = self._build_models(models)
+        query_parts = [self._build_model_query(models)]
 
-        query = Query().model_type_ == entity_model.__name__.lower()
         for key, value in fields.items():
             if isinstance(value, str):
-                query = query & (Query()[key].search(value))
+                query_parts.append(Query()[key].search(value))
             else:
-                query = query & (Query()[key] == value)
+                query_parts.append(Query()[key] == value)
+
+        query = self._build_query(query_parts)
+
+        # Build entities
         entities_data = self.db_.search(query)
 
         for entity_data in entities_data:
-            entities.append(self._build_entity(entity_data, entity_model))
+            entities.append(self._build_entity(entity_data))
 
         if len(entities) == 0:
-            raise EntityNotFoundError(
-                f"There are no {entity_model.__name__}s that match the search filter"
-                f" {fields}"
+            raise self._model_not_found(
+                models, f" that match the search filter {fields}"
             )
 
         return entities
+
+    def _build_model_query(
+        self,
+        models: Models[Entity],
+    ) -> QueryInstance:
+        """Build the Query parts from the models.
+
+        Args:
+            models: Type of entity object to obtain.
+
+        Returns:
+            List of query parts based on the type of models
+        """
+        query_parts = []
+
+        for model in models:
+            query_parts.append(Query().model_type_ == model.__name__.lower())
+
+        return self._build_query(query_parts, mode="or")
+
+    @staticmethod
+    def _build_query(
+        query_parts: List[QueryInstance], mode: str = "and"
+    ) -> QueryInstance:
+        """Build the query from the query parts.
+
+        Args:
+            query_parts: List of queries to concatenate.
+            mode: "and" or "or" for the join method.
+
+        Returns:
+            A query object that joins all parts.
+        """
+        query = query_parts[0]
+
+        for query_part in query_parts[1:]:
+            if mode == "and":
+                query = query & query_part
+            else:
+                query = query | query_part
+
+        return query
 
     def apply_migrations(self, migrations_directory: str) -> None:
         """Run the migrations of the repository schema.
@@ -217,34 +271,28 @@ class TinyDBRepository(AbstractRepository):
         """
         raise NotImplementedError
 
-    def last(self, entity_model: Type[Entity], index: bool = True) -> Entity:
-        """Get the greatest entity from the repository.
+    def last(self, models: OptionalModelOrModels[Entity] = None) -> Entity:
+        """Get the biggest entity from the repository.
 
         Args:
-            entity_model: Type of entity object to obtain.
-            index: Check only commited entities.
+            models: Entity class or classes to obtain.
 
         Returns:
-            entity: Entity object that matches the search criteria.
+            entity: Biggest Entity object of type models.
 
         Raises:
             EntityNotFoundError: If there are no entities.
         """
         try:
-            last_index_entity = super().last(entity_model)
+            last_index_entity: Entity = super().last(models)
         except EntityNotFoundError as empty_repo:
-            if not index:
-                try:
-                    # Empty repo but entities staged to be commited.
-                    return max(self.staged["add"])
-                except ValueError as no_staged_entities:
-                    # Empty repo and no entities staged.
-                    raise empty_repo from no_staged_entities
-            raise empty_repo
+            try:
+                # Empty repo but entities staged to be commited.
+                return max(self.staged["add"])
+            except ValueError as no_staged_entities:
+                # Empty repo and no entities staged.
+                raise empty_repo from no_staged_entities
 
-        # For some reason the insert_entities is not adding the model_type_ attribute
-        if index:
-            return last_index_entity
         try:
             last_staged_entity = max(self.staged["add"])
         except ValueError:

--- a/src/repository_orm/exceptions.py
+++ b/src/repository_orm/exceptions.py
@@ -1,10 +1,9 @@
-"""
-Module to store the repository-orm exceptions.
-
-Exceptions:
-    EntityNotFoundError
-"""
+"""Store the repository-orm exceptions."""
 
 
 class EntityNotFoundError(Exception):
     """Raised when the search or retrieve of an entity fails."""
+
+
+class AutoIncrementError(Exception):
+    """Raised when the id_ auto increment repository feature fails."""

--- a/src/repository_orm/exceptions.py
+++ b/src/repository_orm/exceptions.py
@@ -5,5 +5,9 @@ class EntityNotFoundError(Exception):
     """Raised when the search or retrieve of an entity fails."""
 
 
+class TooManyEntitiesError(Exception):
+    """Raised when more entities than expected where found."""
+
+
 class AutoIncrementError(Exception):
     """Raised when the id_ auto increment repository feature fails."""

--- a/src/repository_orm/model.py
+++ b/src/repository_orm/model.py
@@ -1,8 +1,10 @@
 """Module to store the common business model of all entities."""
 
-from typing import Any
+from typing import Any, Union
 
 from pydantic import BaseModel, PrivateAttr
+
+EntityID = Union[int, str]
 
 
 class Entity(BaseModel):
@@ -14,7 +16,7 @@ class Entity(BaseModel):
     An entity with a negative id means that the id needs to be set by the repository.
     """
 
-    id_: int = -1
+    id_: EntityID = -1
     _model_name: str = PrivateAttr()
 
     def __init__(self, **data: Any) -> None:
@@ -31,7 +33,10 @@ class Entity(BaseModel):
         Raises:
             TypeError: If the id type of the objects is not compatible.
         """
-        return self.id_ < other.id_
+        if not isinstance(other.id_, type(self.id_)):
+            raise TypeError(f"{self} and {other} have incompatible ID types")
+        # ignore: we've checked that both elements are of the same type
+        return self.id_ < other.id_  # type: ignore
 
     def __gt__(self, other: "Entity") -> bool:
         """Assert if an object is greater than us.
@@ -42,7 +47,10 @@ class Entity(BaseModel):
         Raises:
             TypeError: If the id type of the objects is not compatible.
         """
-        return self.id_ > other.id_
+        if not isinstance(other.id_, type(self.id_)):
+            raise TypeError(f"{self} and {other} have incompatible ID types")
+        # ignore: we've checked that both elements are of the same type
+        return self.id_ > other.id_  # type: ignore
 
     def __hash__(self) -> int:
         """Create an unique hash of the class object."""

--- a/src/repository_orm/services.py
+++ b/src/repository_orm/services.py
@@ -4,15 +4,18 @@ Classes and functions that connect the different domain model objects with the a
 and handlers to achieve the program's purpose.
 """
 
-from typing import Optional, Union
+from typing import Optional, TypeVar, Union
 
 from .adapters import FakeRepository, Models, PypikaRepository, TinyDBRepository
+from .model import Entity as EntityModel
 
 Repository = Union[FakeRepository, PypikaRepository, TinyDBRepository]
 
+Entity = TypeVar("Entity", bound=EntityModel)
+
 
 def load_repository(
-    models: Optional[Models] = None, database_url: Optional[str] = None
+    models: Optional[Models[Entity]] = None, database_url: Optional[str] = None
 ) -> Repository:
     """Load the Repository object that matches the database_url protocol.
 

--- a/src/repository_orm/services.py
+++ b/src/repository_orm/services.py
@@ -6,12 +6,14 @@ and handlers to achieve the program's purpose.
 
 from typing import Optional, Union
 
-from .adapters import FakeRepository, PypikaRepository, TinyDBRepository
+from .adapters import FakeRepository, Models, PypikaRepository, TinyDBRepository
 
 Repository = Union[FakeRepository, PypikaRepository, TinyDBRepository]
 
 
-def load_repository(database_url: Optional[str] = None) -> Repository:
+def load_repository(
+    models: Optional[Models] = None, database_url: Optional[str] = None
+) -> Repository:
     """Load the Repository object that matches the database_url protocol.
 
     Args:
@@ -21,10 +23,10 @@ def load_repository(database_url: Optional[str] = None) -> Repository:
         Repository that understands the url protocol.
     """
     if database_url is None or "fake://" in database_url:
-        repo: Repository = FakeRepository()
+        repo: Repository = FakeRepository(models, "")
     elif "sqlite://" in database_url:
-        repo = PypikaRepository(database_url)
+        repo = PypikaRepository(models, database_url)
     elif "tinydb://" in database_url:
-        repo = TinyDBRepository(database_url)
+        repo = TinyDBRepository(models, database_url)
 
     return repo

--- a/tests/cases/__init__.py
+++ b/tests/cases/__init__.py
@@ -4,12 +4,13 @@ Import the created cases so they are easily accessible too.
 """
 
 from .entities import EntityCases, IntEntityCases, StrEntityCases
-from .model import Entity
+from .model import Entity, OtherEntity
 from .repositories import RepositoryCases
 from .testers import RepositoryTester
 
 __all__ = [
     "Entity",
+    "OtherEntity",
     "RepositoryCases",
     "EntityCases",
     "RepositoryTester",

--- a/tests/cases/__init__.py
+++ b/tests/cases/__init__.py
@@ -3,9 +3,16 @@
 Import the created cases so they are easily accessible too.
 """
 
-from .entities import EntityCases
+from .entities import EntityCases, IntEntityCases, StrEntityCases
 from .model import Entity
 from .repositories import RepositoryCases
 from .testers import RepositoryTester
 
-__all__ = ["Entity", "RepositoryCases", "EntityCases", "RepositoryTester"]
+__all__ = [
+    "Entity",
+    "RepositoryCases",
+    "EntityCases",
+    "RepositoryTester",
+    "IntEntityCases",
+    "StrEntityCases",
+]

--- a/tests/cases/entities.py
+++ b/tests/cases/entities.py
@@ -21,10 +21,30 @@ class EntityCases:
         return GenreFactory
 
 
+class StrEntityCases:
+    """Gather all the entities to test with type(id_) == str."""
+
+    def case_author(self) -> factory.Factory:
+        """Return the Author factory."""
+        return AuthorFactory
+
+
+class IntEntityCases:
+    """Gather all the entities to test with type(id_) == int."""
+
+    def case_book(self) -> factory.Factory:
+        """Return the Book factory."""
+        return BookFactory
+
+    def case_genre(self) -> factory.Factory:
+        """Return the Genre factory."""
+        return GenreFactory
+
+
 class AuthorFactory(factory.Factory):  # type: ignore
     """Factory to generate fake authors."""
 
-    id_ = factory.Faker("pyint")
+    id_ = factory.Faker("word")
     name = factory.Faker("word")
     last_name = factory.Faker("last_name")
     country = factory.Faker("country")

--- a/tests/cases/model.py
+++ b/tests/cases/model.py
@@ -34,3 +34,9 @@ class Genre(Entity):
 
     description: Optional[str] = None
     rating: Optional[int] = None
+
+
+class OtherEntity(Entity):
+    """Entity to model an entity that is not in the repo."""
+
+    description: Optional[str] = None

--- a/tests/cases/model.py
+++ b/tests/cases/model.py
@@ -15,6 +15,7 @@ class Entity(EntityModel):
 class Author(Entity):
     """Entity to model the author of a book."""
 
+    id_: str
     last_name: Optional[str] = None
     country: Optional[str] = None
     rating: Optional[int] = None

--- a/tests/cases/repositories.py
+++ b/tests/cases/repositories.py
@@ -1,7 +1,7 @@
 """Gather the repository cases."""
 
 import sqlite3
-from typing import Tuple
+from typing import Tuple, TypeVar
 
 from tinydb import TinyDB
 
@@ -12,11 +12,14 @@ from repository_orm import (
     TinyDBRepository,
 )
 
+from .model import Entity as EntityModel
 from .testers import (
     FakeRepositoryTester,
     PypikaRepositoryTester,
     TinyDBRepositoryTester,
 )
+
+Entity = TypeVar("Entity", bound=EntityModel)
 
 
 class RepositoryCases:
@@ -24,7 +27,9 @@ class RepositoryCases:
 
     def case_fake(
         self, repo_fake: FakeRepository
-    ) -> Tuple[FakeRepositoryDB, FakeRepository, FakeRepository, FakeRepositoryTester]:
+    ) -> Tuple[
+        FakeRepositoryDB[Entity], FakeRepository, FakeRepository, FakeRepositoryTester
+    ]:
         """Return the objects to test the FakeRepository.
 
         Returns:

--- a/tests/cases/repositories.py
+++ b/tests/cases/repositories.py
@@ -6,7 +6,6 @@ from typing import Tuple
 from tinydb import TinyDB
 
 from repository_orm import (
-    Entity,
     FakeRepository,
     FakeRepositoryDB,
     PypikaRepository,
@@ -25,12 +24,7 @@ class RepositoryCases:
 
     def case_fake(
         self, repo_fake: FakeRepository
-    ) -> Tuple[
-        FakeRepositoryDB[Entity],
-        FakeRepository,
-        FakeRepository,
-        FakeRepositoryTester,
-    ]:
+    ) -> Tuple[FakeRepositoryDB, FakeRepository, FakeRepository, FakeRepositoryTester]:
         """Return the objects to test the FakeRepository.
 
         Returns:

--- a/tests/cases/testers.py
+++ b/tests/cases/testers.py
@@ -16,19 +16,13 @@ from repository_orm import (
     FakeRepository,
     FakeRepositoryDB,
     PypikaRepository,
-    Repository,
     TinyDBRepository,
 )
 
-RepositoryTester = TypeVar(
-    "RepositoryTester",
-    "FakeRepositoryTester",
-    "PypikaRepositoryTester",
-    "TinyDBRepositoryTester",
-)
+Repository = TypeVar("Repository")
 
 
-class AbstractRepositoryTester(abc.ABC, Generic[Repository]):
+class RepositoryTester(abc.ABC, Generic[Repository]):
     """Gather common methods and define the interface of the repository testers."""
 
     @abc.abstractmethod
@@ -57,10 +51,9 @@ class AbstractRepositoryTester(abc.ABC, Generic[Repository]):
         raise NotImplementedError
 
 
-# E1136: false positive: https://github.com/PyCQA/pylint/issues/2822
 # R0201: We can't define the method as a class function to maintain the parent interface
 # W0613: We require these arguments to maintain the parent interface.
-class FakeRepositoryTester(AbstractRepositoryTester[FakeRepository]):  # noqa: E1136
+class FakeRepositoryTester(RepositoryTester[FakeRepository]):
     """Gathers methods needed to test the implementation of the FakeRepository."""
 
     def apply_migrations(self, repo: FakeRepository) -> None:
@@ -105,8 +98,7 @@ class FakeRepositoryTester(AbstractRepositoryTester[FakeRepository]):  # noqa: E
         database[type(entity)][entity.id_] = entity
 
 
-# E1136: false positive: https://github.com/PyCQA/pylint/issues/2822
-class TinyDBRepositoryTester(AbstractRepositoryTester[TinyDBRepository]):  # noqa E1136
+class TinyDBRepositoryTester(RepositoryTester[TinyDBRepository]):
     """Gathers methods needed to test the implementation of the TinyDBRepository."""
 
     def assert_schema_exists(
@@ -193,8 +185,7 @@ class TinyDBRepositoryTester(AbstractRepositoryTester[TinyDBRepository]):  # noq
             file_cursor.write(json.dumps(cursor))
 
 
-# E1136 false positive: https://github.com/PyCQA/pylint/issues/2822
-class PypikaRepositoryTester(AbstractRepositoryTester[PypikaRepository]):  # noqa: E1136
+class PypikaRepositoryTester(RepositoryTester[PypikaRepository]):
     """Gathers methods needed to test the implementation of the PypikaRepository."""
 
     @staticmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,14 @@ from repository_orm import (
     TinyDBRepository,
 )
 
-from .cases import Entity, EntityCases, RepositoryCases, RepositoryTester
+from .cases import (
+    Entity,
+    EntityCases,
+    IntEntityCases,
+    RepositoryCases,
+    RepositoryTester,
+    StrEntityCases,
+)
 
 # ---------------------
 # - Database fixtures -
@@ -144,6 +151,41 @@ def entity(entity_factory: factory.Factory) -> Entity:
 
 
 @fixture
+@parametrize_with_cases("entity_factory", cases=StrEntityCases)
+def str_entity(entity_factory: factory.Factory) -> Entity:
+    """Return one entity for each entity type defined in the StrEntityCases."""
+    return entity_factory.create()
+
+
+@fixture
+@parametrize_with_cases("entity_factory", cases=IntEntityCases)
+def int_entity(entity_factory: factory.Factory) -> Entity:
+    """Return one entity for each entity type defined in the IntEntityCases."""
+    return entity_factory.create()
+
+
+@fixture
+@parametrize_with_cases("entity_factory", cases=EntityCases)
+def entities(entity_factory: factory.Factory) -> List[Entity]:
+    """Return three entities for each entity type defined in the EntityCases."""
+    return sorted(entity_factory.create_batch(3))
+
+
+@fixture
+@parametrize_with_cases("entity_factory", cases=StrEntityCases)
+def str_entities(entity_factory: factory.Factory) -> List[Entity]:
+    """Return three entities for each entity type defined in the StrEntityCases."""
+    return sorted(entity_factory.create_batch(3))
+
+
+@fixture
+@parametrize_with_cases("entity_factory", cases=IntEntityCases)
+def int_entities(entity_factory: factory.Factory) -> List[Entity]:
+    """Return three entities for each entity type defined in the IntEntityCases."""
+    return sorted(entity_factory.create_batch(3))
+
+
+@fixture
 # I don't know how to avoid the W0621 error with pytest-cases
 def inserted_entity(
     entity: Entity, database: Any, repo_tester: RepositoryTester  # noqa: W0621
@@ -157,10 +199,29 @@ def inserted_entity(
 
 
 @fixture
-@parametrize_with_cases("entity_factory", cases=EntityCases)
-def entities(entity_factory: factory.Factory) -> List[Entity]:
-    """Return three entities for each entity type defined in the EntityCases."""
-    return sorted(entity_factory.create_batch(3))
+# I don't know how to avoid the W0621 error with pytest-cases
+def inserted_int_entity(
+    int_entity: Entity, database: Any, repo_tester: RepositoryTester  # noqa: W0621
+) -> Entity:
+    """Insert one entity with int id_ in the repository and return it.
+
+    For each entity type defined in the EntityCases.
+    """
+    repo_tester.insert_entity(database, int_entity)
+    return int_entity
+
+
+@fixture
+# I don't know how to avoid the W0621 error with pytest-cases
+def inserted_str_entity(
+    str_entity: Entity, database: Any, repo_tester: RepositoryTester  # noqa: W0621
+) -> Entity:
+    """Insert one entity with str id_ in the repository and return it.
+
+    For each entity type defined in the EntityCases.
+    """
+    repo_tester.insert_entity(database, str_entity)
+    return str_entity
 
 
 @fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,20 +87,20 @@ models = [Author, Book, Genre, OtherEntity]
 @pytest.fixture()
 def repo_fake() -> FakeRepository:
     """Return an instance of the FakeRepository."""
-    return FakeRepository(models=models)  # type: ignore
+    return FakeRepository(models=models)
 
 
 @pytest.fixture(name="repo_tinydb")
 def repo_tinydb_(db_tinydb: Tuple[str, TinyDB]) -> TinyDBRepository:
     """Return an instance of the TinyDBRepository."""
-    return TinyDBRepository(database_url=db_tinydb[0], models=models)  # type: ignore
+    return TinyDBRepository(database_url=db_tinydb[0], models=models)
 
 
 @pytest.fixture(name="empty_repo_pypika")
 def empty_repo_pypika_(db_sqlite: Tuple[str, sqlite3.Cursor]) -> PypikaRepository:
     """Configure an empty instance of the PypikaRepository."""
     sqlite_url = db_sqlite[0]
-    return PypikaRepository(database_url=sqlite_url, models=models)  # type: ignore
+    return PypikaRepository(database_url=sqlite_url, models=models)
 
 
 @pytest.fixture()
@@ -118,8 +118,8 @@ def repo_test_fixture(
     database_: Any,
     empty_repo_: Repository,
     repo_: Repository,
-    repo_tester_: RepositoryTester,
-) -> Tuple[Any, Repository, Repository, RepositoryTester]:
+    repo_tester_: RepositoryTester[Repository],
+) -> Tuple[Any, Repository, Repository, RepositoryTester[Repository]]:
     """Generate the required fixtures to test the repositories.
 
     It creates a tuple containing:
@@ -190,7 +190,9 @@ def int_entities(entity_factory: factory.Factory) -> List[Entity]:
 @fixture
 # I don't know how to avoid the W0621 error with pytest-cases
 def inserted_entity(
-    entity: Entity, database: Any, repo_tester: RepositoryTester  # noqa: W0621
+    entity: Entity,
+    database: Any,
+    repo_tester: RepositoryTester[Repository],  # noqa: W0621
 ) -> Entity:
     """Insert one entity in the repository and return it.
 
@@ -203,7 +205,9 @@ def inserted_entity(
 @fixture
 # I don't know how to avoid the W0621 error with pytest-cases
 def inserted_int_entity(
-    int_entity: Entity, database: Any, repo_tester: RepositoryTester  # noqa: W0621
+    int_entity: Entity,
+    database: Any,
+    repo_tester: RepositoryTester[Repository],  # noqa: W0621
 ) -> Entity:
     """Insert one entity with int id_ in the repository and return it.
 
@@ -216,7 +220,9 @@ def inserted_int_entity(
 @fixture
 # I don't know how to avoid the W0621 error with pytest-cases
 def inserted_str_entity(
-    str_entity: Entity, database: Any, repo_tester: RepositoryTester  # noqa: W0621
+    str_entity: Entity,
+    database: Any,
+    repo_tester: RepositoryTester[Repository],  # noqa: W0621
 ) -> Entity:
     """Insert one entity with str id_ in the repository and return it.
 
@@ -229,7 +235,9 @@ def inserted_str_entity(
 @fixture
 # I don't know how to avoid the W0621 error with pytest-cases
 def inserted_entities(
-    entities: List[Entity], database: Any, repo_tester: RepositoryTester  # noqa: W0621
+    entities: List[Entity],
+    database: Any,
+    repo_tester: RepositoryTester[Repository],  # noqa: W0621
 ) -> List[Entity]:
     """Insert three entities in the repository and return them.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ from .cases import (
     RepositoryTester,
     StrEntityCases,
 )
+from .cases.model import Author, Book, Genre, OtherEntity
 
 # ---------------------
 # - Database fixtures -
@@ -80,25 +81,26 @@ def db_tinydb_(tmpdir: LocalPath) -> Tuple[str, TinyDB]:
 # -----------------------
 # - Repository fixtures -
 # -----------------------
+models = [Author, Book, Genre, OtherEntity]
 
 
 @pytest.fixture()
 def repo_fake() -> FakeRepository:
     """Return an instance of the FakeRepository."""
-    return FakeRepository()
+    return FakeRepository(models=models)  # type: ignore
 
 
 @pytest.fixture(name="repo_tinydb")
 def repo_tinydb_(db_tinydb: Tuple[str, TinyDB]) -> TinyDBRepository:
     """Return an instance of the TinyDBRepository."""
-    return TinyDBRepository(db_tinydb[0])
+    return TinyDBRepository(database_url=db_tinydb[0], models=models)  # type: ignore
 
 
 @pytest.fixture(name="empty_repo_pypika")
 def empty_repo_pypika_(db_sqlite: Tuple[str, sqlite3.Cursor]) -> PypikaRepository:
     """Configure an empty instance of the PypikaRepository."""
     sqlite_url = db_sqlite[0]
-    return PypikaRepository(sqlite_url)
+    return PypikaRepository(database_url=sqlite_url, models=models)  # type: ignore
 
 
 @pytest.fixture()

--- a/tests/migrations/pypika/0001_initial_schema.py
+++ b/tests/migrations/pypika/0001_initial_schema.py
@@ -36,4 +36,13 @@ steps = [
         "PRIMARY KEY (id))",
         "DROP TABLE genre",
     ),
+    step(
+        "CREATE TABLE otherentity ("
+        "id INT, "
+        "name VARCHAR(20), "
+        "description VARCHAR(255), "
+        "rating INT, "
+        "PRIMARY KEY (id))",
+        "DROP TABLE otherentity",
+    ),
 ]

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -1,5 +1,7 @@
 """Tests the model layer."""
 
+import pytest
+
 from repository_orm import Entity
 
 
@@ -47,3 +49,41 @@ def test_model_name_returns_expected_name() -> None:
     result = entity._model_name
 
     assert result == "Entity"
+
+
+def test_compare_less_than_entities_with_string_ids() -> None:
+    """Comparison between entities is done by the ID attribute on string IDS."""
+    small = Entity(id_="a")
+    big = Entity(id_="b")
+
+    result = small < big
+
+    assert result
+
+
+def test_compare_greater_than_entities_with_string_ids() -> None:
+    """Comparison between entities is done by the ID attribute on string IDS."""
+    small = Entity(id_="a")
+    big = Entity(id_="b")
+
+    result = big > small
+
+    assert result
+
+
+def test_compare_less_than_entities_cant_compare_string_and_id() -> None:
+    """Raise TypeError if one object id is a string and the other an int"""
+    entity_string = Entity(id_="a")
+    entity_int = Entity(id_=1)
+
+    with pytest.raises(TypeError):
+        entity_string < entity_int  # noqa: B015, W0104
+
+
+def test_compare_greater_than_entities_cant_compare_string_and_id() -> None:
+    """Raise TypeError if one object id is a string and the other an int"""
+    entity_string = Entity(id_="a")
+    entity_int = Entity(id_=1)
+
+    with pytest.raises(TypeError):
+        entity_string > entity_int  # noqa: B015, W0104

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -12,6 +12,8 @@ from repository_orm import (
     load_repository,
 )
 
+from ..cases.model import Author
+
 
 def test_load_repository_loads_fake_by_default() -> None:
     """
@@ -30,7 +32,7 @@ def test_load_repository_loads_fake_with_fake_urls() -> None:
     When: load_repository is called without argument
     Then: a working FakeRepository instance is returned
     """
-    result = load_repository("fake://fake.db")
+    result = load_repository(database_url="fake://fake.db")
 
     assert isinstance(result, FakeRepository)
 
@@ -43,7 +45,7 @@ def test_load_repository_loads_pypika_with_sqlite_urls(
     When: load_repository is called without argument
     Then: a working FakeRepository instance is returned
     """
-    result = load_repository(db_sqlite[0])
+    result = load_repository(database_url=db_sqlite[0])
 
     assert isinstance(result, PypikaRepository)
 
@@ -56,6 +58,19 @@ def test_load_repository_loads_tinydb_with_sqlite_urls(
     When: load_repository is called without argument
     Then: a working FakeRepository instance is returned
     """
-    result = load_repository(db_tinydb[0])
+    result = load_repository(database_url=db_tinydb[0])
 
     assert isinstance(result, TinyDBRepository)
+
+
+def test_load_repository_loads_models() -> None:
+    """
+    Given: Nothing
+    When: load_repository is called with the models.
+    Then: they are saved
+    """
+    models = [Author]
+
+    result = load_repository(models=models)
+
+    assert result.models == models


### PR DESCRIPTION
<!--
Thank you for sending a pull request!

Please describe what the change is, trying to link it with open issues.
-->
feat: make entity models optional arguments of the repo methods

Right now the `entity_model` is a mandatory argument for these methods, that
means that the code calling the repository needs to be aware of all the entity
models inside the repository and call the methods for each of them.

Change the signatures of the `get`, `search`, `all`, `first` and `last` methods
to accept one, many or no `Entity` subclasses. If none is given, it will assume
that the repository was initialized with the `models` argument, where the user
gives the repo the model of the data it holds.

For the sake of cleanness, we're renaming `entity_models` for `models` in the
function arguments.

BREAKING: The argument `entity_model` is no longer the first one for the methods `get` and `search`, but the second.
BREAKING: The argument `database_url` is no longer the first argument in the `load_repository` function, but the second, being the first the `models`.

refactor: create the _model_not_found and _build_models abstract repo methods

chore: update requirements

## Checklist

* [x] Add test cases to all the changes you introduce
* [x] Update the documentation for the changes
