### PR TITLE
feat: partially support search in attributes of type List

### DIFF
--- a/src/repository_orm/adapters/tinydb.py
+++ b/src/repository_orm/adapters/tinydb.py
@@ -1,7 +1,9 @@
 """Define the TinyDB Repository."""
 
 import os
-from typing import Any, Dict, List
+import re
+from contextlib import suppress
+from typing import Any, Dict, Iterable, List
 
 from tinydb import Query, TinyDB
 from tinydb.queries import QueryInstance
@@ -142,7 +144,7 @@ class TinyDBRepository(Repository):
             entities_data = self.db_.search(query)
 
         for entity_data in entities_data:
-            entities.append(self._build_entity(entity_data))
+            entities.append(self._build_entity(entity_data, models))
 
         return entities
 
@@ -197,21 +199,13 @@ class TinyDBRepository(Repository):
         """
         entities: List[Entity] = []
         models = self._build_models(models)
-        query_parts = [self._build_model_query(models)]
-
-        for key, value in fields.items():
-            if isinstance(value, str):
-                query_parts.append(Query()[key].search(value))
-            else:
-                query_parts.append(Query()[key] == value)
-
-        query = self._build_query(query_parts)
+        query = self._build_search_query(fields, models)
 
         # Build entities
         entities_data = self.db_.search(query)
 
         for entity_data in entities_data:
-            entities.append(self._build_entity(entity_data))
+            entities.append(self._build_entity(entity_data, models))
 
         if len(entities) == 0:
             raise self._model_not_found(
@@ -219,6 +213,53 @@ class TinyDBRepository(Repository):
             )
 
         return entities
+
+    def _build_search_query(
+        self,
+        fields: Dict[str, EntityID],
+        models: Models[Entity],
+    ) -> QueryInstance:
+        """Build the Query parts for a repository search.
+
+        Select only the models that contain the fields. If the field type is a list,
+        change the query accordingly.
+
+        Args:
+            models: Type of entity object to obtain.
+            fields: Dictionary with the {key}:{value} to search.
+
+        Returns:
+            Query based on the type of models and fields.
+        """
+        query_parts = []
+
+        for model in models:
+            schema = model.schema()["properties"]
+            for field, value in fields.items():
+                if field not in schema.keys():
+                    continue
+
+                with suppress(KeyError):
+                    if schema[field]["type"] == "array":
+                        query_parts.append(
+                            (Query().model_type_ == model.__name__.lower())
+                            & (Query()[field].test(_regexp_in_list, value))
+                        )
+                        continue
+
+                if isinstance(value, str):
+                    query_parts.append(
+                        (Query().model_type_ == model.__name__.lower())
+                        & (Query()[field].search(value))
+                    )
+                else:
+                    query_parts.append(Query()[field] == value)
+        if len(query_parts) == 0:
+            raise self._model_not_found(
+                models, f" that match the search filter {fields}"
+            )
+
+        return self._merge_query(query_parts, mode="or")
 
     def _build_model_query(
         self,
@@ -237,13 +278,13 @@ class TinyDBRepository(Repository):
         for model in models:
             query_parts.append(Query().model_type_ == model.__name__.lower())
 
-        return self._build_query(query_parts, mode="or")
+        return self._merge_query(query_parts, mode="or")
 
     @staticmethod
-    def _build_query(
+    def _merge_query(
         query_parts: List[QueryInstance], mode: str = "and"
     ) -> QueryInstance:
-        """Build the query from the query parts.
+        """Join all the query parts into a query.
 
         Args:
             query_parts: List of queries to concatenate.
@@ -301,3 +342,10 @@ class TinyDBRepository(Repository):
 
         # Full repo and staged entities.
         return max([last_index_entity, last_staged_entity])
+
+
+def _regexp_in_list(list_: Iterable[Any], regular_expression: str) -> bool:
+    """Test if regexp matches any element of the list."""
+    regexp = re.compile(regular_expression)
+
+    return any(regexp.search(element) for element in list_)

--- a/src/repository_orm/adapters/tinydb.py
+++ b/src/repository_orm/adapters/tinydb.py
@@ -348,4 +348,7 @@ def _regexp_in_list(list_: Iterable[Any], regular_expression: str) -> bool:
     """Test if regexp matches any element of the list."""
     regexp = re.compile(regular_expression)
 
-    return any(regexp.search(element) for element in list_)
+    try:
+        return any(regexp.search(element) for element in list_)
+    except TypeError:
+        return False

--- a/tests/cases/entities.py
+++ b/tests/cases/entities.py
@@ -2,7 +2,7 @@
 
 import factory
 
-from .model import Author, Book, Genre
+from .model import Author, Book, Genre, ListEntity
 
 
 class EntityCases:
@@ -83,3 +83,16 @@ class GenreFactory(factory.Factory):  # type: ignore
         """Define the entity model object to use."""
 
         model = Genre
+
+
+class ListEntityFactory(factory.Factory):  # type: ignore
+    """Factory to generate fake genres."""
+
+    id_ = factory.Faker("pyint")
+    name = factory.Faker("name")
+    elements = factory.Faker("pylist", value_types=str)
+
+    class Meta:
+        """Define the entity model object to use."""
+
+        model = ListEntity

--- a/tests/cases/model.py
+++ b/tests/cases/model.py
@@ -1,7 +1,7 @@
 """Store a default model use case to use in the tests."""
 
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional
 
 from repository_orm import Entity as EntityModel
 
@@ -40,3 +40,9 @@ class OtherEntity(Entity):
     """Entity to model an entity that is not in the repo."""
 
     description: Optional[str] = None
+
+
+class ListEntity(Entity):
+    """Entity to model an entity that has a list of strings attribute."""
+
+    elements: List[str]

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -16,6 +16,8 @@ from repository_orm import AutoIncrementError, EntityNotFoundError, Repository
 from repository_orm.exceptions import TooManyEntitiesError
 
 from ..cases import Entity, OtherEntity, RepositoryTester
+from ..cases.entities import ListEntityFactory
+from ..cases.model import ListEntity
 
 
 def test_apply_repository_creates_schema(  # noqa: AAA01
@@ -523,6 +525,26 @@ def test_repository_can_search_by_multiple_properties(
     result = repo.search(search_criteria, type(entity))
 
     assert result == [entity]
+
+
+@pytest.mark.skip(
+    "Supported by Fake and TinyDB, not by Pypika yet. Once mappers are supported "
+    "it should be easy to add this particular case."
+)
+def test_repo_can_search_in_list_of_str_attribute(repo: Repository) -> None:
+    """
+    Given: A repository with an entity that contains an attribute with a list of str
+    When: search is called with a regexp that  matches one of the list elements
+    Then: the entity is returned
+    """
+    expected_entity = ListEntityFactory.create()
+    repo.add(expected_entity)
+    repo.commit()
+    regexp = fr"{expected_entity.elements[0][:-1]}."
+
+    result = repo.search({"elements": regexp}, ListEntity)
+
+    assert result == [expected_entity]
 
 
 @pytest.mark.secondary()

--- a/tests/migrations/pypika/0001_initial_schema.py
+++ b/tests/migrations/pypika/0001_initial_schema.py
@@ -45,4 +45,20 @@ steps = [
         "PRIMARY KEY (id))",
         "DROP TABLE otherentity",
     ),
+    step(
+        "CREATE TABLE listentity ("
+        "id INT, "
+        "name VARCHAR(20), "
+        "description VARCHAR(255), "
+        "PRIMARY KEY (id))",
+        "DROP TABLE listentity",
+    ),
+    step(
+        "CREATE TABLE listentity_has_elements ("
+        "id INT, "
+        "entity_id INT,"
+        "element VARCHAR(255), "
+        "PRIMARY KEY (id))",
+        "DROP TABLE listentity_has_elements",
+    ),
 ]


### PR DESCRIPTION
Allow to search for regular expressions in attributes of type
`List[str]`. FakeRepository and TinyDBRepository support it now, but
PypikaRepository doesn't, and the implementation is no trivial and I'm
in a hurry, so I'm leaving the test commented and not documenting the
feature until it is supported by all repositories.

Once the mappers are merged, this should not be difficult.

<!--
Thank you for sending a pull request!

Please describe what the change is, trying to link it with open issues.
-->

## Checklist

* [x] Add test cases to all the changes you introduce
* [ ] Update the documentation for the changes
