### PR TITLE
fix: make tinydb search return only entities of the asked model

### DIFF
--- a/src/repository_orm/adapters/fake.py
+++ b/src/repository_orm/adapters/fake.py
@@ -161,7 +161,7 @@ class FakeRepository(Repository):
                 ) from error
 
             for path in entities_with_value["matched_values"]:
-                entity_id = re.sub(r"root\[(.*?)\]\[.*", r"\1", path)
+                entity_id = re.sub(r"root\['?(.*?)'?\]\[.*", r"\1", path)
 
                 # Convert int ids from str to int
                 try:

--- a/src/repository_orm/adapters/tinydb.py
+++ b/src/repository_orm/adapters/tinydb.py
@@ -272,7 +272,10 @@ class TinyDBRepository(Repository):
                         & (Query()[field].search(value))
                     )
                 else:
-                    model_query_parts.append(Query()[field] == value)
+                    model_query_parts.append(
+                        (Query().model_type_ == model.__name__.lower())
+                        & (Query()[field] == value)
+                    )
             if len(model_query_parts) != 0:
                 query_parts.append(self._merge_query(model_query_parts, mode="and"))
         if len(query_parts) == 0:

--- a/tests/cases/entities.py
+++ b/tests/cases/entities.py
@@ -44,8 +44,8 @@ class IntEntityCases:
 class AuthorFactory(factory.Factory):  # type: ignore
     """Factory to generate fake authors."""
 
-    id_ = factory.Faker("word")
-    name = factory.Faker("word")
+    id_ = factory.Faker("sentence")
+    name = factory.Faker("sentence")
     last_name = factory.Faker("last_name")
     country = factory.Faker("country")
     rating = factory.Faker("pyint")
@@ -75,7 +75,7 @@ class GenreFactory(factory.Factory):  # type: ignore
     """Factory to generate fake genres."""
 
     id_ = factory.Faker("pyint")
-    name = factory.Faker("name")
+    name = factory.Faker("sentence")
     description = factory.Faker("sentence")
     rating = factory.Faker("pyint")
 
@@ -89,7 +89,7 @@ class ListEntityFactory(factory.Factory):  # type: ignore
     """Factory to generate fake list of entities."""
 
     id_ = factory.Faker("pyint")
-    name = factory.Faker("name")
+    name = factory.Faker("sentence")
     elements = factory.Faker("pylist", value_types=str)
 
     class Meta:

--- a/tests/cases/model.py
+++ b/tests/cases/model.py
@@ -11,6 +11,7 @@ class Entity(EntityModel):
 
     name: str
     state: str = "open"
+    active: bool = True
 
 
 class Author(Entity):

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -23,7 +23,7 @@ from repository_orm.exceptions import TooManyEntitiesError
 
 from ..cases import Entity, OtherEntity, RepositoryTester
 from ..cases.entities import ListEntityFactory
-from ..cases.model import BoolEntity, ListEntity
+from ..cases.model import Author, Book, BoolEntity, ListEntity
 
 
 def test_apply_repository_creates_schema(  # noqa: AAA01
@@ -550,6 +550,44 @@ def test_repository_can_search_by_multiple_properties(
     result = repo.search({"state": entity.state, "name": entity.name}, type(entity))
 
     assert result == [entity]
+
+
+def test_repo_can_search_entity_if_two_different_entities_match(
+    repo: Repository,
+) -> None:
+    """
+    Given: Two different entities with the same ID
+    When: we search by a property equal in both entities and give only one model.
+    Then: only the entity that matches the model is returned
+    """
+    author = Author(id_="author_id", name="common name")
+    book = Book(id_=1, name="common name")
+    repo.add(author)
+    repo.add(book)
+    repo.commit()
+
+    result = repo.search({"name": "common name"}, [Author])
+
+    assert result == [author]
+
+
+def test_repo_can_search_entity_if_two_different_entities_match_giving_both_models(
+    repo: Repository,
+) -> None:
+    """
+    Given: Two different entities with the same ID
+    When: we search by a property equal in both entities and give both models.
+    Then: both entities that matches the model are returned
+    """
+    author = Author(id_="author_id", name="common name")
+    book = Book(id_=1, name="common name")
+    repo.add(author)
+    repo.add(book)
+    repo.commit()
+
+    result = repo.search({"name": "common name"}, [Author, Book])
+
+    assert result == [author, book]
 
 
 @pytest.mark.skip(

--- a/tests/migrations/pypika/0001_initial_schema.py
+++ b/tests/migrations/pypika/0001_initial_schema.py
@@ -14,6 +14,7 @@ steps = [
         "last_name VARCHAR(20), "
         "country VARCHAR(20), "
         "state VARCHAR(20), "
+        "active BOOL, "
         "rating INT, "
         "PRIMARY KEY (id))",
         "DROP TABLE author",
@@ -25,6 +26,7 @@ steps = [
         "summary VARCHAR(255), "
         "state VARCHAR(20), "
         "released DATETIME, "
+        "active BOOL, "
         "rating INT, "
         "PRIMARY KEY (id))",
         "DROP TABLE book",
@@ -36,6 +38,7 @@ steps = [
         "description VARCHAR(255), "
         "state VARCHAR(20), "
         "rating INT, "
+        "active BOOL, "
         "PRIMARY KEY (id))",
         "DROP TABLE genre",
     ),
@@ -46,6 +49,7 @@ steps = [
         "state VARCHAR(20), "
         "description VARCHAR(255), "
         "rating INT, "
+        "active BOOL, "
         "PRIMARY KEY (id))",
         "DROP TABLE otherentity",
     ),
@@ -55,6 +59,7 @@ steps = [
         "name VARCHAR(20), "
         "state VARCHAR(20), "
         "description VARCHAR(255), "
+        "active BOOL, "
         "PRIMARY KEY (id))",
         "DROP TABLE listentity",
     ),


### PR DESCRIPTION
If two entities of different models had the same bool attribute, when
searching for that attribute it returned all the models instead of just
the one asked.

<!--
Thank you for sending a pull request!

Please describe what the change is, trying to link it with open issues.
-->

## Checklist

* [ ] Add test cases to all the changes you introduce
* [ ] Update the documentation for the changes
