### PR TITLE
feat: add file repositories

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/lyz-code/cookiecutter-python-project",
-  "commit": "7ddf0d825eb90ba7561141cf8944cdb2cde13760",
+  "commit": "26d95cab240d78b065cffd54036ab916aa70a034",
   "checkout": null,
   "context": {
     "cookiecutter": {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Set up Python 3.7
+      - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.9
       - name: Install dependencies
         run: pip install wheel
       - name: Build package
@@ -42,9 +42,10 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.9
       - name: Install dependencies
         run: >-
+          pip install -r requirements.txt
           pip install -r ./docs/requirements.txt
           pip install -e .
       - name: Build the Documentation

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9, '3.10']
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9, '3.10']
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python ${{ matrix.python-version }}
@@ -63,10 +63,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Set up Python 3.7
+      - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.9
       - name: Install PEP517
         run: >-
           python -m

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -12,10 +12,10 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-      - name: Set up Python 3.7
+      - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.9
       - name: Install dependencies
         run: pip install pip-tools
       - name: Update requirements
@@ -26,6 +26,7 @@ jobs:
         run: make all
       - name: Commit files
         run: |
+          rm -r .git/hooks
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add requirements.txt docs/requirements.txt requirements-dev.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,11 +15,11 @@ repos:
   #     - id: black
   #       language_version: python3.7
   - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
-    rev: v1.1.3
+    rev: v1.2.2
     hooks:
       - id: python-safety-dependencies-check
-  - repo: https://github.com/life4/flakehell/
-    rev: master
+  - repo: https://github.com/flakehell/flakehell/
+    rev: v.0.9.0
     hooks:
       - name: Run flakehell static analysis tool
         id: flakehell

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ black = black --target-version py37 src docs/examples tests setup.py
 
 .PHONY: install
 install:
-	python -m pip install -U setuptools pip
-	pip install -r requirements-dev.txt
+	python -m pip install -U setuptools pip pip-tools
+	python -m piptools sync requirements.txt requirements-dev.txt docs/requirements.txt
 	pip install -e .
 	pre-commit install
 
@@ -14,6 +14,9 @@ update:
 	@echo "-------------------------"
 	@echo "- Updating dependencies -"
 	@echo "-------------------------"
+
+  # Sync your virtualenv with the expected state
+	python -m piptools sync requirements.txt requirements-dev.txt docs/requirements.txt
 
 	pip install -U pip
 
@@ -29,7 +32,10 @@ update:
 	touch requirements-dev.txt
 	pip-compile -Ur --allow-unsafe requirements-dev.in --output-file requirements-dev.txt
 
-	pip install -r requirements-dev.txt
+  # Sync your virtualenv with the new state
+	python -m piptools sync requirements.txt requirements-dev.txt docs/requirements.txt
+
+	pip install -e .
 
 	@echo ""
 

--- a/docs/examples/auto_increment_id.py
+++ b/docs/examples/auto_increment_id.py
@@ -5,7 +5,7 @@ class Author(Entity):
     first_name: str
 
 
-repo = load_repository([Author])
+repo = load_repository()
 
 
 author = Author(first_name="Brandon")
@@ -15,5 +15,5 @@ repo.add(author)
 repo.commit()
 
 # Retrieve entities by their ID
-brandon = repo.get(0)
+brandon = repo.get(0, Author)
 assert brandon == author

--- a/docs/examples/e2e_test.py
+++ b/docs/examples/e2e_test.py
@@ -33,7 +33,7 @@ def create_greeting(repo: Repository) -> str:
 @click.command()
 @click.argument("database_url")
 def greet(database_url: str) -> None:
-    repo = load_repository([Author], database_url)
+    repo = load_repository(database_url)
 
     print(create_greeting(repo))
 

--- a/docs/examples/file_repository.py
+++ b/docs/examples/file_repository.py
@@ -1,0 +1,23 @@
+import os
+
+from repository_orm import File, load_file_repository
+
+repo = load_file_repository("local:/tmp/file_data")
+
+file_ = File(path="test.txt")
+file_._content = "File content"
+
+# Save content in the repository
+
+file_ = repo.save(file_)
+assert file_.path == "/tmp/file_data/test.txt"
+assert os.path.isfile(file_.path)
+
+# Load the content from the repository
+file_ = File(path="test.txt")
+file_ = repo.load(file_)
+assert file_.content == "File content"
+
+# Remove the file content from the repository
+repo.delete(file_)
+assert not os.path.isfile("/tmp/file_data/test.txt")

--- a/docs/examples/simple-example.py
+++ b/docs/examples/simple-example.py
@@ -7,7 +7,7 @@ class Author(Entity):
     country: str
 
 
-repo = load_repository([Author])
+repo = load_repository()
 
 author = Author(first_name="Brandon", last_name="Sanderson", country="US")
 
@@ -16,11 +16,11 @@ repo.add(author)
 repo.commit()
 
 # Retrieve entities by their ID
-brandon = repo.get(0)
+brandon = repo.get(0, Author)
 assert brandon == author
 
 # Search entities
-brandon = repo.search({"first_name": "Brandon"})[0]
+brandon = repo.search({"first_name": "Brandon"}, Author)[0]
 assert brandon == author
 
 # Delete entities

--- a/docs/fake_repository.md
+++ b/docs/fake_repository.md
@@ -1,4 +1,4 @@
-The [`FakeRepository`][repository_orm.adapters.fake.FakeRepository] is the
+The [`FakeRepository`][repository_orm.adapters.data.fake.FakeRepository] is the
 simplest implementation of the repository pattern, meant to be used for the
 tests and early phases of development.
 
@@ -22,23 +22,23 @@ repo = load_repository()
 Follow the [overview example](index.md#a-simple-example) to see how to use each
 method.
 
-[`add`][repository_orm.adapters.fake.FakeRepository.add]
+[`add`][repository_orm.adapters.data.fake.FakeRepository.add]
 : Appends the `Entity` object to the `new_entities` attribute.
 
-[`delete`][repository_orm.adapters.fake.FakeRepository.delete]
+[`delete`][repository_orm.adapters.data.fake.FakeRepository.delete]
 : Deletes the `Entity` object from the `new_entities` attribute.
 
-[`get`][repository_orm.adapters.fake.FakeRepository.get]
+[`get`][repository_orm.adapters.data.fake.FakeRepository.get]
 : Obtain an `Entity` from the `entities` attribute by it's ID.
 
-[`commit`][repository_orm.adapters.fake.FakeRepository.commit]
+[`commit`][repository_orm.adapters.data.fake.FakeRepository.commit]
 : Persist the changes of `new_entities` into `entities`, clearing up
     `new_entities` afterwards.
 
-[`all`][repository_orm.adapters.fake.FakeRepository.all]
+[`all`][repository_orm.adapters.data.fake.FakeRepository.all]
 : Obtain all the entities of type `Entity` from the `entities` attribute.
 
-[`search`][repository_orm.adapters.fake.FakeRepository.search]
+[`search`][repository_orm.adapters.data.fake.FakeRepository.search]
 : Obtain the entities whose attributes match one or multiple conditions.
 
     We use [DeepDiff's](https://deepdiff.readthedocs.io)
@@ -46,7 +46,7 @@ method.
     to search for the entities that have the value we're searching for and then
     we search if the key of those entities match the one we're searching for.
 
-[`apply_migrations`][repository_orm.adapters.fake.FakeRepository.apply_migrations]
+[`apply_migrations`][repository_orm.adapters.data.fake.FakeRepository.apply_migrations]
 : Run the migrations of the repository schema.
 
     As the fake repository doesn't have any schema this method does nothing.

--- a/docs/file_repositories.md
+++ b/docs/file_repositories.md
@@ -1,0 +1,38 @@
+---
+title: File Repositories
+date: 20211202
+author: Lyz
+---
+
+File repositories give a common interface to store computer file contents.
+
+They only persist the content of [File][repository_orm.model.File] objects into the
+different backends. The metadata however is not stored, so you'll need to use
+a [data repository](repositories.md) for that.
+
+# A Simple Example
+
+```python
+{! examples/file_repository.py !} # noqa
+```
+
+# Usage
+
+The different repositories share the next operations:
+
+`load`
+: Load the content of the file from the persistence system.
+
+`save`
+: Save the content of the file into the persistence system.
+
+`delete`
+: Delete the file from the persistence system.
+
+# Repositories
+
+To change the repository you only need to change the url passed to
+`load_file_repository`. We have the next repositories:
+
+* [LocalFileRepository](local_file_repository.md): stores the file contents in
+    the local file system.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,9 +2,9 @@
 [![Actions Status](https://github.com/lyz-code/repository-orm/workflows/Build/badge.svg)](https://github.com/lyz-code/repository-orm/actions)
 [![Coverage Status](https://coveralls.io/repos/github/lyz-code/repository-orm/badge.svg?branch=master)](https://coveralls.io/github/lyz-code/repository-orm?branch=master)
 
-Library to ease the implementation of the [repository
-pattern](https://lyz-code.github.io/blue-book/architecture/repository_pattern/)
-in python projects.
+Library to persist [Pydantic](https://pydantic-docs.helpmanual.io/) models into
+different storage backends following the [repository
+pattern](https://lyz-code.github.io/blue-book/architecture/repository_pattern/).
 
 # Installing
 
@@ -60,62 +60,14 @@ But the following disadvantages:
 * Supplying test classes and fixtures so extending the provided repositories is
     easy.
 
-
-# Usage
-
-The different repositories share the next operations:
-
-`add`
-: Add an `Entity` object to the repository, if it already exist, it updates the
-    stored attributes.
-
-`delete`
-: Remove an `Entity` object form the repository.
-
-`get`
-: Obtain an `Entity` from the repository by it's ID.
-
-`commit`
-: Persist the changes into the repository.
-
-`all`
-: Get all the entities of a type or types from the repository. If no argument is
-given, it will return all entities.
-
-`search`
-: Get the entities whose attributes match a condition or regular expression.
-
-`first`
-: Get the first entity of a type or types of the repository. If no argument is
-given, it will return the first of any type of entity.
-
-`last`
-: Get the last entity of a type or types of the repository. If no argument is
-given, it will return the first of any type of entity.
-
-`apply_migrations`
-: Run the migrations of the repository schema.
-
-!!! note ""
-    Changes in the repository aren't persisted until you run `repo.commit()`.
-
 # Repositories
 
-To change the repository you only need to change the url passed to
-`load_repository`. We have the next repositories:
+There are two kinds of repositories:
 
-* [FakeRepository](fake_repository.md): is the simplest implementation of the
-    repository pattern, meant to be used for the tests and early phases of
-    development.
-* [TinyDBRepository](tinydb_repository.md): is the implementation of the
-    repository pattern for the local NoSQL
-    [TinyDB](https://tinydb.readthedocs.io/en/latest/usage.html) database. You
-    can use it in the early stages of the project where the data schema is yet
-    unstable and you don't have enough entities to have performance issues.
-* [PypikaRepository](pypika_repository.md): is the implementation of the
-    repository pattern for the relational databases. It's meant for the stages
-    of the project where the schema is more stable and you need the improved
-    performance of these types of databases.
+* [*Data repositories*](repositories.md): Give a common interface to store the
+    models in databases.
+* [*File repositories*](file_repositories.md): Give a common interface to store
+    computer file contents.
 
 # References
 

--- a/docs/local_file_repository.md
+++ b/docs/local_file_repository.md
@@ -1,0 +1,27 @@
+The [`LocalFileRepository`][repository_orm.adapters.file.LocalFileRepository] stores the file contents in the local file system.
+
+It stores the [File][repository_orm.model.File]'s contents in a file in the
+local file system.
+
+Imagine you want to save the contents in `/srv/file_data`, you'll then
+initialize the repository with:
+
+```python
+from repository_orm import load_file_repository
+
+repo = load_file_repository("local:/srv/file_data")
+```
+
+# Features
+
+Follow the [overview example](file_repositories.md#a-simple-example) to see how to use each
+method.
+
+[`load`][repository_orm.adapters.file.local_file.LocalFileRepository.load]
+: Load the content of the File from a file in the local filesystem.
+
+[`save`][repository_orm.adapters.file.local_file.LocalFileRepository.save]
+: Save the content of the File to a file in the local filesystem.
+
+[`delete`][repository_orm.adapters.file.local_file.LocalFileRepository.delete]
+: Delete the file from the local filesystem.

--- a/docs/models.md
+++ b/docs/models.md
@@ -15,7 +15,7 @@ you usually need the following object types:
 
 # Entities
 
-We've created the [Entity][repository_orm.model.Entity] class based on the
+The [Entity][repository_orm.model.Entity] class is based on the
 pydantic's `BaseModel` to enforce that they have the `id_` attribute of type
 `int` or `str`, used for comparison and hashing of entities.
 
@@ -30,3 +30,27 @@ populate it.
 ```
 
 !!! warning "This won't work with `str` ids!"
+
+# Files
+
+The [File][repository_orm.model.File] class is a special
+[Entity][repository_orm.model.Entity] model used to work with computer files.
+
+It has useful attributes like:
+
+* `path`.
+* `created_at`.
+* `updated_at`.
+* `owner`.
+* `group`.
+* `permissions`.
+
+And methods:
+
+* `basename`.
+* `dirname`.
+* `extension`.
+
+Until Pydantic `1.9` is released, you need to store the content in the file
+using the `_content` attribute, to access the content, you can use `content`
+directly.

--- a/docs/pypika_repository.md
+++ b/docs/pypika_repository.md
@@ -1,4 +1,4 @@
-The [`PypikaRepository`][repository_orm.adapters.pypika.PypikaRepository] is the
+The [`PypikaRepository`][repository_orm.adapters.data.pypika.PypikaRepository] is the
 implementation of the repository pattern for the relational databases. It's
 meant for the stages of the project where the schema is more stable and you need
 the improved performance of these types of databases.
@@ -46,33 +46,33 @@ of the tests if you need an example.
 Follow the [overview example](index.md#a-simple-example) to see how to use each
 method.
 
-[`add`][repository_orm.adapters.pypika.PypikaRepository.add]
+[`add`][repository_orm.adapters.data.pypika.PypikaRepository.add]
 : Appends the `Entity` object to its table by translating its attributes to the
     columns. If it already exists, use the [upsert
     statement](https://www.sqlite.org/lang_UPSERT.html) to update it's
     attributes in the table.
 
-[`delete`][repository_orm.adapters.pypika.PypikaRepository.delete]
+[`delete`][repository_orm.adapters.data.pypika.PypikaRepository.delete]
 : Deletes the `Entity` object from its table by searching the row that matches
     the object ID.
 
-[`get`][repository_orm.adapters.pypika.PypikaRepository.get]
+[`get`][repository_orm.adapters.data.pypika.PypikaRepository.get]
 : Obtain an `Entity` by extracting the row that matches the ID and build the
     `Entity` object with that data.
 
-[`commit`][repository_orm.adapters.pypika.PypikaRepository.commit]
+[`commit`][repository_orm.adapters.data.pypika.PypikaRepository.commit]
 : Persist the changes into the database.
 
-[`all`][repository_orm.adapters.pypika.PypikaRepository.all]
+[`all`][repository_orm.adapters.data.pypika.PypikaRepository.all]
 : Obtain all the entities of type `Entity`. Similar to the `get` method but for
     all entities.
 
-[`search`][repository_orm.adapters.pypika.PypikaRepository.search]
+[`search`][repository_orm.adapters.data.pypika.PypikaRepository.search]
 : Obtain the entities whose attributes match one or multiple conditions. We
     create a query with all the desired criteria and then build the entities with
     the obtained data.
 
-[`apply_migrations`][repository_orm.adapters.pypika.PypikaRepository.apply_migrations]
+[`apply_migrations`][repository_orm.adapters.data.pypika.PypikaRepository.apply_migrations]
 : Run the migrations of the repository schema. Creates a yoyo connection and
     runs all the scripts in the `migrations` directory.
 

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -1,0 +1,63 @@
+---
+title: Data Repositories
+date: 20211202
+author: Lyz
+---
+
+Data repositories give a common interface to store the models in databases.
+
+# Usage
+
+The different repositories share the next operations:
+
+`add`
+: Add an `Entity` object to the repository, if it already exist, it updates the
+    stored attributes.
+
+`delete`
+: Remove an `Entity` object form the repository.
+
+`get`
+: Obtain an `Entity` from the repository by it's ID.
+
+`commit`
+: Persist the changes into the repository.
+
+`all`
+: Get all the entities of a type or types from the repository. If no argument is
+given, it will return all entities.
+
+`search`
+: Get the entities whose attributes match a condition or regular expression.
+
+`first`
+: Get the first entity of a type or types of the repository. If no argument is
+given, it will return the first of any type of entity.
+
+`last`
+: Get the last entity of a type or types of the repository. If no argument is
+given, it will return the first of any type of entity.
+
+`apply_migrations`
+: Run the migrations of the repository schema.
+
+!!! note ""
+    Changes in the repository aren't persisted until you run `repo.commit()`.
+
+# Repositories
+
+To change the repository you only need to change the url passed to
+`load_repository`. We have the next repositories:
+
+* [FakeRepository](fake_repository.md): is the simplest implementation of the
+    repository pattern, meant to be used for the tests and early phases of
+    development.
+* [TinyDBRepository](tinydb_repository.md): is the implementation of the
+    repository pattern for the local NoSQL
+    [TinyDB](https://tinydb.readthedocs.io/en/latest/usage.html) database. You
+    can use it in the early stages of the project where the data schema is yet
+    unstable and you don't have enough entities to have performance issues.
+* [PypikaRepository](pypika_repository.md): is the implementation of the
+    repository pattern for the relational databases. It's meant for the stages
+    of the project where the schema is more stable and you need the improved
+    performance of these types of databases.

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -1,4 +1,4 @@
--r requirements.txt
+-c requirements.txt
 
 mkdocs
 mkdocs-git-revision-date-localized-plugin

--- a/docs/tinydb_repository.md
+++ b/docs/tinydb_repository.md
@@ -1,4 +1,4 @@
-The [`TinyDBRepository`][repository_orm.adapters.tinydb.TinyDBRepository] is the
+The [`TinyDBRepository`][repository_orm.adapters.data.tinydb.TinyDBRepository] is the
 implementation of the repository pattern for the local NoSQL
 [TinyDB](https://tinydb.readthedocs.io/en/latest/usage.html) database. You can
 use it in the early stages of the project where the data schema is yet unstable
@@ -20,33 +20,33 @@ repo = load_repository('tinydb://path/to/database.db')
 Follow the [overview example](index.md#a-simple-example) to see how to use each
 method.
 
-[`add`][repository_orm.adapters.tinydb.TinyDBRepository.add]
+[`add`][repository_orm.adapters.data.tinydb.TinyDBRepository.add]
 : Appends the `Entity` object to the default table by translating its attributes
     to a valid json row. If it already exists, it uses the [upsert
     statement](https://tinydb.readthedocs.io/en/latest/usage.html?highlight=upsert#upserting-data)
     to update it's attributes in the table.
 
-[`delete`][repository_orm.adapters.tinydb.TinyDBRepository.delete]
+[`delete`][repository_orm.adapters.data.tinydb.TinyDBRepository.delete]
 : Deletes the `Entity` object from the collection by searching the row that
     matches the object ID.
 
-[`get`][repository_orm.adapters.tinydb.TinyDBRepository.get]
+[`get`][repository_orm.adapters.data.tinydb.TinyDBRepository.get]
 : Obtain an `Entity` by extracting the row that matches the ID and build the
     `Entity` object with that data.
 
-[`commit`][repository_orm.adapters.tinydb.TinyDBRepository.commit]
+[`commit`][repository_orm.adapters.data.tinydb.TinyDBRepository.commit]
 : Persist the changes into the database.
 
-[`all`][repository_orm.adapters.tinydb.TinyDBRepository.all]
+[`all`][repository_orm.adapters.data.tinydb.TinyDBRepository.all]
 : Obtain all the entities of type `Entity`. Similar to the `get` method but for
     all entities.
 
-[`search`][repository_orm.adapters.tinydb.TinyDBRepository.search]
+[`search`][repository_orm.adapters.data.tinydb.TinyDBRepository.search]
 : Obtain the entities whose attributes match one or multiple conditions. We
     create a query with all the desired criteria and then build the entities with
     the obtained data.
 
-[`apply_migrations`][repository_orm.adapters.tinydb.TinyDBRepository.apply_migrations]
+[`apply_migrations`][repository_orm.adapters.data.tinydb.TinyDBRepository.apply_migrations]
 : We don't yet [support migrations on the
     schema](https://github.com/lyz-code/repository-orm/issues/27), so the models
     should be flexible enough to absorb the changes, or you can code your

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,9 +5,13 @@ site_url: https://lyz-code.github.io/repository-orm
 nav:
   - Repository ORM: index.md
   - Repositories:
+      - repositories.md
       - FakeRepository: fake_repository.md
       - TinyDBRepository: tinydb_repository.md
       - PypikaRepository: pypika_repository.md
+  - File Repositories:
+      - file_repositories.md
+      - LocalFileRepository: local_file_repository.md
   - Models: models.md
   - Testing: testing.md
   - API Reference:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ version_files = [
 
 [tool.black]
 line-length = 88
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py37', 'py38', 'py39', 'py310']
 include = '\.pyi?$'
 exclude = '''
 /(
@@ -46,7 +46,6 @@ norecursedirs = [
     "*/static/*",
     "docs",
     "venv",
-    "*/Repository ORM/*"
 ]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
@@ -59,6 +58,9 @@ markers = [
 exclude_lines = [
     # Have to re-enable the standard pragma
     'pragma: no cover',
+
+    # Type checking can not be tested
+    'if TYPE_CHECKING:',
 
     # Ignore the Abstract classes definition
     'raise NotImplementedError',

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,5 +1,5 @@
--r requirements.txt
--r docs/requirements.in
+-c requirements.txt
+-c docs/requirements.in
 
 # Testing
 pytest
@@ -35,6 +35,10 @@ flake8-markdown
 pylint
 pre-commit
 dlint
+
+# Remove the next dependency when https://github.com/flakehell/flakehell/issues/22
+# is resolved
+flake8<4.0.0
 
 # Security
 pip-tools

--- a/src/repository_orm/__init__.py
+++ b/src/repository_orm/__init__.py
@@ -1,18 +1,18 @@
 """Library to ease the implementation of the repository pattern in Python projects."""
 
-from .adapters import (
-    FakeRepository,
-    FakeRepositoryDB,
+from .adapters.data.abstract import (
     Models,
     OptionalModelOrModels,
     OptionalModels,
-    PypikaRepository,
     Repository,
-    TinyDBRepository,
 )
+from .adapters.data.fake import FakeRepository, FakeRepositoryDB
+from .adapters.data.pypika import PypikaRepository
+from .adapters.data.tinydb import TinyDBRepository
+from .adapters.file.local_file import LocalFileRepository
 from .exceptions import AutoIncrementError, EntityNotFoundError
-from .model import Entity, EntityID
-from .services import load_repository
+from .model import Entity, EntityID, File
+from .services import load_file_repository, load_repository
 
 __all__ = [
     "AutoIncrementError",
@@ -20,7 +20,9 @@ __all__ = [
     "EntityID",
     "EntityNotFoundError",
     "FakeRepository",
+    "File",
     "FakeRepositoryDB",
+    "LocalFileRepository",
     "Models",
     "OptionalModels",
     "OptionalModelOrModels",
@@ -29,4 +31,5 @@ __all__ = [
     "Repository",
     "TinyDBRepository",
     "load_repository",
+    "load_file_repository",
 ]

--- a/src/repository_orm/adapters/data/abstract.py
+++ b/src/repository_orm/adapters/data/abstract.py
@@ -3,9 +3,9 @@
 import abc
 from typing import Dict, List, Optional, Type, TypeVar, Union
 
-from ..exceptions import AutoIncrementError, EntityNotFoundError
-from ..model import Entity as EntityModel
-from ..model import EntityID
+from ...exceptions import AutoIncrementError, EntityNotFoundError
+from ...model import Entity as EntityModel
+from ...model import EntityID
 
 # no cover: The lines with the flag are being tested by it's subclasses.
 

--- a/src/repository_orm/adapters/data/fake.py
+++ b/src/repository_orm/adapters/data/fake.py
@@ -7,8 +7,8 @@ from typing import Dict, List, Type
 
 from deepdiff import extract, grep
 
-from ..exceptions import EntityNotFoundError, TooManyEntitiesError
-from ..model import EntityID
+from ...exceptions import EntityNotFoundError, TooManyEntitiesError
+from ...model import EntityID
 from .abstract import Entity, Models, OptionalModelOrModels, OptionalModels, Repository
 
 FakeRepositoryDB = Dict[Type[Entity], Dict[EntityID, Entity]]

--- a/src/repository_orm/adapters/data/pypika.py
+++ b/src/repository_orm/adapters/data/pypika.py
@@ -11,8 +11,8 @@ from typing import Dict, List, Type, Union
 from pypika import Query, Table
 from yoyo import get_backend, read_migrations
 
-from ..exceptions import EntityNotFoundError, TooManyEntitiesError
-from ..model import EntityID
+from ...exceptions import EntityNotFoundError, TooManyEntitiesError
+from ...model import EntityID
 from .abstract import Entity, OptionalModelOrModels, OptionalModels, Repository
 
 log = logging.getLogger(__name__)

--- a/src/repository_orm/adapters/data/tinydb.py
+++ b/src/repository_orm/adapters/data/tinydb.py
@@ -15,8 +15,8 @@ from tinydb_serialization.serializers import DateTimeSerializer
 
 from repository_orm.exceptions import TooManyEntitiesError
 
-from ..exceptions import EntityNotFoundError
-from ..model import EntityID
+from ...exceptions import EntityNotFoundError
+from ...model import EntityID
 from .abstract import Entity, Models, OptionalModelOrModels, OptionalModels, Repository
 
 log = logging.getLogger(__name__)

--- a/src/repository_orm/adapters/file/abstract.py
+++ b/src/repository_orm/adapters/file/abstract.py
@@ -1,0 +1,36 @@
+"""Define the abstract interface for file repositories."""
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, AnyStr, Generic
+
+from pydantic import BaseModel  # noqa: E0611
+
+if TYPE_CHECKING:
+    from ...model import File
+
+
+class FileRepository(BaseModel, ABC, Generic[AnyStr]):
+    """Define the interface of the file repositories."""
+
+    workdir: str = "."
+
+    @abstractmethod
+    def load(self, file_: "File[AnyStr]") -> "File[AnyStr]":
+        """Load the content of the file from the persistence system."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def save(self, file_: "File[AnyStr]") -> "File[AnyStr]":
+        """Save the content of the file into the persistence system."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def delete(self, file_: "File[AnyStr]") -> None:
+        """Delete the file from the persistence system."""
+        raise NotImplementedError
+
+    def fix_path(self, file_: "File[AnyStr]") -> "File[AnyStr]":
+        """Update the path to include the workdir."""
+        if self.workdir not in file_.path:
+            file_.path = f"{self.workdir}/{file_.path}"
+        return file_

--- a/src/repository_orm/adapters/file/local_file.py
+++ b/src/repository_orm/adapters/file/local_file.py
@@ -1,0 +1,61 @@
+"""Define the local filesystem adapter."""
+
+import logging
+import os
+from typing import AnyStr
+
+from ...model import File
+from .abstract import FileRepository
+
+log = logging.getLogger(__name__)
+
+
+class LocalFileRepository(FileRepository[AnyStr]):
+    """Define the local filesystem adapter."""
+
+    def __init__(self, workdir: str) -> None:
+        """Initialize the object.
+
+        Creates the working directory if it doesn't exist.
+        """
+        if not os.path.exists(workdir):
+            os.makedirs(workdir)
+        super().__init__(workdir=workdir)
+
+    def load(self, file_: File[AnyStr]) -> File[AnyStr]:
+        """Load the content of the file from the persistence system."""
+        log.debug(f"Loading content of file {file_.path}")
+        file_ = self.fix_path(file_)
+        if file_.is_bytes:
+            mode = "rb"
+        else:
+            mode = "r"
+
+        with open(os.path.expanduser(file_.path), mode) as file_descriptor:
+            file_._content = file_descriptor.read()
+        return file_
+
+    def save(self, file_: File[AnyStr]) -> File[AnyStr]:
+        """Save the content of the file into the persistence system."""
+        log.debug(f"Saving the content of file {file_.path}")
+        file_ = self.fix_path(file_)
+        if file_.is_bytes:
+            mode = "wb+"
+        else:
+            mode = "w+"
+
+        with open(os.path.expanduser(file_.path), mode) as file_descriptor:
+            file_descriptor.write(file_.content)
+
+        return file_
+
+    def delete(self, file_: File[AnyStr]) -> None:
+        """Delete the file from the persistence system."""
+        log.debug(f"Deleting the content of file {file_.path}")
+        try:
+            os.remove(os.path.expanduser(file_.path))
+        except FileNotFoundError:
+            log.warning(
+                f"Can't remove the file {file_.path} as it doesn't exist "
+                "in the file repository."
+            )

--- a/src/repository_orm/exceptions.py
+++ b/src/repository_orm/exceptions.py
@@ -11,3 +11,7 @@ class TooManyEntitiesError(Exception):
 
 class AutoIncrementError(Exception):
     """Raised when the id_ auto increment repository feature fails."""
+
+
+class FileContentNotLoadedError(Exception):
+    """Raised when trying to access the content of a file that has not been loaded."""

--- a/src/repository_orm/services.py
+++ b/src/repository_orm/services.py
@@ -1,4 +1,4 @@
-"""Gather all the orchestration functionality required by the program to work.
+"""Define all the orchestration functionality required by the program to work.
 
 Classes and functions that connect the different domain model objects with the adapters
 and handlers to achieve the program's purpose.

--- a/src/repository_orm/services.py
+++ b/src/repository_orm/services.py
@@ -4,10 +4,17 @@ Classes and functions that connect the different domain model objects with the a
 and handlers to achieve the program's purpose.
 """
 
-from typing import Optional, TypeVar, Union
+from typing import TYPE_CHECKING, AnyStr, Optional, TypeVar, Union
 
-from .adapters import FakeRepository, Models, PypikaRepository, TinyDBRepository
+from .adapters.data.abstract import Models
+from .adapters.data.fake import FakeRepository
+from .adapters.data.pypika import PypikaRepository
+from .adapters.data.tinydb import TinyDBRepository
+from .adapters.file.local_file import LocalFileRepository
 from .model import Entity as EntityModel
+
+if TYPE_CHECKING:
+    from .adapters.file.abstract import FileRepository
 
 Repository = Union[FakeRepository, PypikaRepository, TinyDBRepository]
 
@@ -15,9 +22,9 @@ Entity = TypeVar("Entity", bound=EntityModel)
 
 
 def load_repository(
-    models: Optional[Models[Entity]] = None, database_url: Optional[str] = None
+    database_url: str = "fake://", models: Optional[Models[Entity]] = None
 ) -> Repository:
-    """Load the Repository object that matches the database_url protocol.
+    """Load the Repository object that matches the database url protocol.
 
     Args:
         database_url: Url to connect to the storage backend.
@@ -25,7 +32,7 @@ def load_repository(
     Returns:
         Repository that understands the url protocol.
     """
-    if database_url is None or "fake://" in database_url:
+    if "fake://" in database_url:
         return FakeRepository(models, "")
     if "sqlite://" in database_url:
         return PypikaRepository(models, database_url)
@@ -33,3 +40,18 @@ def load_repository(
         return TinyDBRepository(models, database_url)
 
     raise ValueError(f"Database URL: {database_url} not recognized.")
+
+
+def load_file_repository(url: str = "local:.") -> "FileRepository[AnyStr]":
+    """Load the FileRepository object that matches the url protocol.
+
+    Args:
+        url: Url to connect to the storage backend.
+
+    Returns:
+        File Repository that understands the url protocol.
+    """
+    if "local:" in url:
+        return LocalFileRepository(workdir=url.split(":")[1])
+
+    raise ValueError(f"File Repository URL: {url} not recognized.")

--- a/tests/cases/repositories.py
+++ b/tests/cases/repositories.py
@@ -1,13 +1,14 @@
 """Gather the repository cases."""
 
 import sqlite3
-from typing import Tuple, TypeVar
+from typing import AnyStr, Tuple, TypeVar
 
 from tinydb import TinyDB
 
 from repository_orm import (
     FakeRepository,
     FakeRepositoryDB,
+    LocalFileRepository,
     PypikaRepository,
     TinyDBRepository,
 )
@@ -15,6 +16,7 @@ from repository_orm import (
 from .model import Entity as EntityModel
 from .testers import (
     FakeRepositoryTester,
+    LocalFileRepositoryTester,
     PypikaRepositoryTester,
     TinyDBRepositoryTester,
 )
@@ -72,3 +74,18 @@ class RepositoryCases:
         """
         # Return a clean database connection
         return db_sqlite[0], empty_repo_pypika, repo_pypika, PypikaRepositoryTester()
+
+
+class FileRepositoryCases:
+    """Gather all the file repositories to test."""
+
+    def case_local_file(
+        self, repo_local_file: LocalFileRepository[AnyStr]
+    ) -> Tuple[LocalFileRepository[AnyStr], LocalFileRepositoryTester[AnyStr]]:
+        """Return the objects to test the LocalFileRepository.
+
+        Returns:
+            repo: A LocalFileRepository with the workdir configured.
+            repo_tester: The tester class for the LocalFilerepository.
+        """
+        return repo_local_file, LocalFileRepositoryTester()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 import os
 import sqlite3
-from typing import Any, Generator, List, Tuple
+from typing import Any, AnyStr, Generator, List, Tuple
 
 import factory
 import pytest
@@ -12,10 +12,12 @@ from tinydb import TinyDB
 
 from repository_orm import (
     FakeRepository,
+    LocalFileRepository,
     PypikaRepository,
     Repository,
     TinyDBRepository,
 )
+from repository_orm.adapters.file.abstract import FileRepository
 
 from .cases import (
     Entity,
@@ -26,6 +28,8 @@ from .cases import (
     StrEntityCases,
 )
 from .cases.model import Author, Book, Genre, OtherEntity
+from .cases.repositories import FileRepositoryCases
+from .cases.testers import FileRepositoryTester
 
 # ---------------------
 # - Database fixtures -
@@ -134,9 +138,42 @@ def repo_test_fixture(
     return database_, empty_repo_, repo_, repo_tester_
 
 
-# We know they are going to return four objects.
+# W0632: We know they are going to return four objects.
 database, empty_repo, repo, repo_tester = unpack_fixture(  # noqa: W0632
     "database,empty_repo,repo,repo_tester", repo_test_fixture
+)
+
+
+# ----------------------------
+# - File Repository fixtures -
+# ----------------------------
+@pytest.fixture(name="repo_local_file")
+def repo_local_file_(tmpdir: LocalPath) -> LocalFileRepository[AnyStr]:
+    """Configure a temporal LocalFileRepository."""
+    return LocalFileRepository(workdir=str(tmpdir))
+
+
+@fixture
+@parametrize_with_cases("file_repo_, file_repo_tester_", cases=FileRepositoryCases)
+def file_repo_test_fixture(
+    file_repo_: FileRepository[AnyStr],
+    file_repo_tester_: FileRepositoryTester[AnyStr],
+) -> Tuple[FileRepository[AnyStr], FileRepositoryTester[AnyStr]]:
+    """Generate the required fixtures to test the file repositories.
+
+    It creates a tuple containing:
+
+    * A configured repository
+    * A tester object
+
+    For each file repository type.
+    """
+    return file_repo_, file_repo_tester_
+
+
+# W0632: We know they are going to return four objects.
+file_repo, file_repo_tester = unpack_fixture(  # noqa: W0632
+    "file_repo,file_repo_tester", file_repo_test_fixture
 )
 
 

--- a/tests/integration/test_file_repository.py
+++ b/tests/integration/test_file_repository.py
@@ -1,0 +1,154 @@
+"""Test the implementation of the FileRepositories."""
+
+import os
+from typing import AnyStr
+
+import pytest
+from _pytest.logging import LogCaptureFixture
+from py._path.local import LocalPath
+
+from repository_orm import File, LocalFileRepository
+from repository_orm.adapters.file.abstract import FileRepository
+
+from ..cases.testers import FileRepositoryTester
+
+# ignore: Argument 1 to "save" of "FileRepository" has incompatible type "File[str]";
+# expected "File[bytes]"  [arg-type].
+# It only happens on the tests, if you use the repository directly it works fine. It
+# might be the type hints of the fixtures, and test cases, but I can't figure out what's
+# wrong.
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param("file content", id="string"),
+        pytest.param(b"file content", id="bytes"),
+    ],
+)
+class TestFileRepositories:
+    """Test the implementation of the file repositories."""
+
+    def test_repo_can_save_file_content(
+        self,
+        file_repo: FileRepository[AnyStr],
+        file_repo_tester: FileRepositoryTester[AnyStr],
+        content: AnyStr,
+    ) -> None:
+        """
+        Given: A File and a FileRepository
+        When: Saving the File into the repository
+        Then: The content of the File is persisted, and the File's path attribute
+            is complemented with the working dir.
+        """
+        if type(content) == bytes:
+            is_bytes = True
+        else:
+            is_bytes = False
+        file_ = File(path="test.txt", is_bytes=is_bytes)
+        file_._content = content  # type: ignore
+
+        result = file_repo.save(file_)  # type: ignore
+
+        assert file_repo_tester.content(file_) == content  # type: ignore
+        assert result.path == f"{file_repo.workdir}/test.txt"
+
+    def test_repo_can_load_file_content(
+        self,
+        file_repo: FileRepository[AnyStr],
+        file_repo_tester: FileRepositoryTester[AnyStr],
+        content: AnyStr,
+    ) -> None:
+        """
+        Given: A File in the Repository
+        When: Loading the File content
+        Then: The content of the File is loaded
+        """
+        if type(content) == bytes:
+            is_bytes = True
+        else:
+            is_bytes = False
+        file_repo_tester.save(content, "test.txt", file_repo.workdir)
+        file_ = File(path="test.txt", is_bytes=is_bytes)
+
+        file_repo.load(file_)  # type: ignore # act
+
+        assert file_.content == content
+
+    def test_repo_can_delete_file_content(
+        self,
+        file_repo: FileRepository[AnyStr],
+        file_repo_tester: FileRepositoryTester[AnyStr],
+        content: AnyStr,
+    ) -> None:
+        """
+        Given: A File in the Repository
+        When: Deleting the file content
+        Then: The content of the File is removed
+        """
+        if type(content) == bytes:
+            is_bytes = True
+        else:
+            is_bytes = False
+        file_repo_tester.save(content, "test.txt", file_repo.workdir)
+        file_ = File(path="test.txt", is_bytes=is_bytes)
+
+        file_repo.delete(file_)  # type: ignore # act
+
+        assert not file_repo_tester.exists("test.txt")
+
+
+def test_repo_raises_error_when_loading_unexistent_file(
+    file_repo: FileRepository[AnyStr],
+    file_repo_tester: FileRepositoryTester[AnyStr],
+) -> None:
+    """
+    Given: Nothing in the Repository
+    When: Loading the File content
+    Then: An error is raised, as there is nothing to load.
+    """
+    file_ = File(path="test.txt")
+
+    with pytest.raises(FileNotFoundError):
+        file_repo.load(file_)  # type: ignore
+
+
+def test_repo_raises_error_when_removing_unexistent_file(
+    file_repo: FileRepository[AnyStr],
+    file_repo_tester: FileRepositoryTester[AnyStr],
+    caplog: LogCaptureFixture,
+) -> None:
+    """
+    Given: Nothing in the Repository
+    When: Removing the File content
+    Then: A warning is raised, as there is nothing to remove.
+    """
+    file_ = File(path="test.txt")
+
+    file_repo.delete(file_)  # type: ignore # act
+
+    assert caplog.record_tuples == [
+        (
+            "repository_orm.adapters.file.local_file",
+            30,
+            "Can't remove the file test.txt as it "
+            "doesn't exist in the file repository.",
+        )
+    ]
+
+
+class TestLocalFileRepository:
+    """Test particular details of the LocalFileRepository."""
+
+    def test_creates_workdir_if_it_doesnt_exist(self, tmpdir: LocalPath) -> None:
+        """
+        Given: Nothing
+        When: Initializing the repository with an inexistent directory
+        Then: The directory is created
+        """
+        workdir = f"{tmpdir}/unexistent_dir"
+
+        result = LocalFileRepository(workdir=workdir)
+
+        assert result.workdir == workdir
+        assert os.path.exists(result.workdir)

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -801,7 +801,7 @@ def test_tinydb_raises_error_if_wrong_model_data(
         repo_tinydb.get(1, [Entity])
 
     assert (
-        "repository_orm.adapters.tinydb",
+        "repository_orm.adapters.data.tinydb",
         logging.ERROR,
         "Error loading the model Entity for the register {'id_': 1}",
     ) in caplog.record_tuples

--- a/tests/unit/model/test_entity.py
+++ b/tests/unit/model/test_entity.py
@@ -1,4 +1,4 @@
-"""Tests the model layer."""
+"""Tests the entity model."""
 
 import pytest
 
@@ -25,17 +25,17 @@ def test_compare_greater_than_entities() -> None:
     assert result
 
 
-def test_hash_uses_the_entity_id() -> None:
+def test_hash_uses_the_entity_id_and_model_name() -> None:
     """
     Given: A configured entity.
     When: The __hash__ method is used.
-    Then: The hash of the identity is used
+    Then: The hash of the identity and model name are used
     """
     entity = Entity(id_=1)
 
     result = entity.__hash__()
 
-    assert result == hash(1)
+    assert result == hash("Entity-1")
 
 
 def test_model_name_returns_expected_name() -> None:

--- a/tests/unit/model/test_file.py
+++ b/tests/unit/model/test_file.py
@@ -1,0 +1,79 @@
+"""Test the File model."""
+
+import pytest
+
+from repository_orm.exceptions import FileContentNotLoadedError
+from repository_orm.model import File
+
+
+def test_file_basename() -> None:
+    """
+    Given: A File object
+    When: using the basename method
+    Then: the name of the file is returned
+    """
+    file_ = File(path="/tmp/file.txt")
+
+    result = file_.basename
+
+    assert result == "file.txt"
+
+
+def test_file_dirname() -> None:
+    """
+    Given: A File object
+    When: using the dirname method
+    Then: the name of the directory containing the file is returned
+    """
+    file_ = File(path="/tmp/file.txt")
+
+    result = file_.dirname
+
+    assert result == "/tmp"
+
+
+def test_file_extension() -> None:
+    """
+    Given: A File object
+    When: using the extension method
+    Then: the extension of the file is returned
+    """
+    file_ = File(path="/tmp/file.txt")
+
+    result = file_.extension
+
+    assert result == "txt"
+
+
+def test_file_content() -> None:
+    """
+    Given: A File object with the content loaded.
+    When: using the content property
+    Then: the content of the file is returned
+
+    The use of a private attribute and the impossibility of loading the content
+    at object creation will be fixed on Pydantic 1.9, for more information on how to
+    improve this code, read this:
+        https://lyz-code.github.io/blue-book/coding/python/pydantic/#define-fields-to-exclude-from-exporting-at-config-level # noqa:E501
+    """
+    file_ = File(path="/tmp/file.txt")
+    file_._content = "content"
+
+    result = file_.content
+
+    assert result == "content"
+
+
+def test_file_content_raises_error_if_empty() -> None:
+    """
+    Given: A File object without any content loaded.
+    When: using the content property
+    Then: an exception is raised.
+    """
+    file_ = File(path="/tmp/file.txt")
+
+    with pytest.raises(
+        FileContentNotLoadedError,
+        match="The content of the file has not been loaded yet.",
+    ):
+        file_.content

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -8,80 +8,115 @@ from tinydb import TinyDB
 
 from repository_orm import (
     FakeRepository,
+    LocalFileRepository,
     PypikaRepository,
     TinyDBRepository,
+    load_file_repository,
     load_repository,
 )
 
 from ..cases.model import Author
 
 
-def test_load_repository_loads_fake_by_default() -> None:
-    """
-    Given: Nothing
-    When: load_repository is called without argument
-    Then: a working FakeRepository instance is returned
-    """
-    result = load_repository()
+class TestLoadRepository:
+    """Test the implementation of the load_repository service."""
 
-    assert isinstance(result, FakeRepository)
+    def test_load_repository_loads_fake_by_default(self) -> None:
+        """
+        Given: Nothing
+        When: load_repository is called without argument
+        Then: a working FakeRepository instance is returned
+        """
+        result = load_repository()
+
+        assert isinstance(result, FakeRepository)
+
+    def test_load_repository_loads_fake_with_fake_urls(self) -> None:
+        """
+        Given: Nothing
+        When: load_repository is called without argument
+        Then: a working FakeRepository instance is returned
+        """
+        result = load_repository(database_url="fake://fake.db")
+
+        assert isinstance(result, FakeRepository)
+
+    def test_load_repository_loads_pypika_with_sqlite_urls(
+        self, db_sqlite: Tuple[str, sqlite3.Cursor]
+    ) -> None:
+        """
+        Given: Nothing
+        When: load_repository is called with a pypika compatible url
+        Then: a working PypikaRepository instance is returned
+        """
+        result = load_repository(database_url=db_sqlite[0])
+
+        assert isinstance(result, PypikaRepository)
+
+    def test_load_repository_loads_tinydb_with_sqlite_urls(
+        self, db_tinydb: Tuple[str, TinyDB]
+    ) -> None:
+        """
+        Given: Nothing
+        When: load_repository is called with a tinydb compatible url
+        Then: a working TinyDBRepository instance is returned
+        """
+        result = load_repository(database_url=db_tinydb[0])
+
+        assert isinstance(result, TinyDBRepository)
+
+    def test_load_repository_returns_error_if_url_not_recognized(self) -> None:
+        """
+        Given: Nothing
+        When: load_repository is called with an unrecognized url
+        Then: An error is raised
+        """
+        with pytest.raises(ValueError, match="Database URL: .* not recognized."):
+            load_repository(database_url="inexistent://path/to/file.db")
+
+    def test_load_repository_loads_models(self) -> None:
+        """
+        Given: Nothing
+        When: load_repository is called with the models.
+        Then: they are saved
+        """
+        models = [Author]
+
+        result = load_repository(models=models)
+
+        assert result.models == models
 
 
-def test_load_repository_loads_fake_with_fake_urls() -> None:
-    """
-    Given: Nothing
-    When: load_repository is called without argument
-    Then: a working FakeRepository instance is returned
-    """
-    result = load_repository(database_url="fake://fake.db")
+class TestLoadFileRepository:
+    """Test the implementation of the load_file_repository service."""
 
-    assert isinstance(result, FakeRepository)
+    def test_load_file_repository_loads_local_by_default(self) -> None:
+        """
+        Given: Nothing
+        When: load_repository is called without argument
+        Then: a working LocalFileRepository instance is returned
+        """
+        result = load_file_repository()
 
+        assert isinstance(result, LocalFileRepository)
+        assert result.workdir == "."
 
-def test_load_repository_loads_pypika_with_sqlite_urls(
-    db_sqlite: Tuple[str, sqlite3.Cursor]
-) -> None:
-    """
-    Given: Nothing
-    When: load_repository is called with a pypika compatible url
-    Then: a working PypikaRepository instance is returned
-    """
-    result = load_repository(database_url=db_sqlite[0])
+    def test_load_file_repository_can_specify_local_repository(self) -> None:
+        """
+        Given: Nothing
+        When: load_repository is called with a local directory
+        Then: a working LocalFileRepository instance is returned
+        """
+        result = load_file_repository("local:/tmp/file_data")
 
-    assert isinstance(result, PypikaRepository)
+        assert isinstance(result, LocalFileRepository)
+        assert result.workdir == "/tmp/file_data"
 
-
-def test_load_repository_loads_tinydb_with_sqlite_urls(
-    db_tinydb: Tuple[str, TinyDB]
-) -> None:
-    """
-    Given: Nothing
-    When: load_repository is called with a tinydb compatible url
-    Then: a working TinyDBRepository instance is returned
-    """
-    result = load_repository(database_url=db_tinydb[0])
-
-    assert isinstance(result, TinyDBRepository)
-
-
-def test_load_repository_returns_error_if_url_not_recognized() -> None:
-    """
-    Given: Nothing
-    When: load_repository is called with an unrecognized url
-    Then: An error is raised
-    """
-    with pytest.raises(ValueError, match="Database URL: .* not recognized."):
-        load_repository(database_url="inexistent://path/to/file.db")
-
-
-def test_load_repository_loads_models() -> None:
-    """
-    Given: Nothing
-    When: load_repository is called with the models.
-    Then: they are saved
-    """
-    models = [Author]
-
-    result = load_repository(models=models)
-
-    assert result.models == models
+    def test_load_file_repository_returns_error_if_url_not_recognized(self) -> None:
+        """
+        Given: Nothing
+        When: load_file_repository is called with an unrecognized url
+        Then: An error is raised
+        """
+        with pytest.raises(ValueError, match="File Repository URL: .* not recognized."):
+            load_file_repository(url="inexistent://path/to/workdir")


### PR DESCRIPTION
File repositories give a common interface to store computer file contents.

A generic `FileRepository` class has been defined to set the interface
of this type of repositories, and the first implementation has been
done, `LocalFilerepository` which stores file contents in the local
filesystem.

A specific `Entity` model `File` has been created for these types of
repositories.

They can be loaded with the `load_file_repository` function.

docs: fix broken examples

fix: make Entity hash unique per model

Now it hashes the modelname + the id. Before if two objects of different
models had the same ID they'd share the same hash

<!--
Thank you for sending a pull request!

Please describe what the change is, trying to link it with open issues.
-->

## Checklist

* [ ] Add test cases to all the changes you introduce
* [ ] Update the documentation for the changes
