### PR TITLE
fix/last bug

### DIFF
--- a/src/repository_orm/adapters/data/tinydb.py
+++ b/src/repository_orm/adapters/data/tinydb.py
@@ -346,18 +346,25 @@ class TinyDBRepository(Repository):
         Raises:
             EntityNotFoundError: If there are no entities.
         """
+        models = self._build_models(models)
         try:
             last_index_entity: Entity = super().last(models)
         except EntityNotFoundError as empty_repo:
             try:
                 # Empty repo but entities staged to be commited.
-                return max(self.staged["add"])
+                return max(
+                    entity
+                    for entity in self.staged["add"]
+                    if entity.__class__ in models
+                )
             except ValueError as no_staged_entities:
                 # Empty repo and no entities staged.
                 raise empty_repo from no_staged_entities
 
         try:
-            last_staged_entity = max(self.staged["add"])
+            last_staged_entity = max(
+                entity for entity in self.staged["add"] if entity.__class__ in models
+            )
         except ValueError:
             # Full repo and no staged entities.
             return last_index_entity


### PR DESCRIPTION
- fix: make cache entries immutable
- bump: version 0.9.0 → 0.9.1
- feat: add close method to the data repositories
- fix: select pdm path editable backed
- ci: use pdm to run the test examples
- ci: run the example tests with pdm
- bump: version 0.9.1 → 0.10.0
- chore: update dependency requirements
- chore: update dependency requirements
- chore: update dependency requirements
- chore: update dependency requirements
- chore: update dependency requirements
- fix: sort the result of `repo.all()`
- feat: allow comparison of entities with different `id_` types
- fix[tinydb]: don't return wrong object types on `last` even if they are staged

<!--
Thank you for sending a pull request!

Please describe what the change is, trying to link it with open issues.
-->

## Checklist

* [ ] Add test cases to all the changes you introduce
* [ ] Update the documentation for the changes
