### PR TITLE
fix/id ordering

### DIFF
--- a/src/repository_orm/model.py
+++ b/src/repository_orm/model.py
@@ -34,6 +34,8 @@ class Entity(BaseModel):
         Args:
             other: Entity to compare.
         """
+        if isinstance(other.id_, int) and isinstance(self.id_, int):
+            return self.id_ < other.id_
         return str(self.id_) < str(other.id_)
 
     def __gt__(self, other: "Entity") -> bool:
@@ -42,6 +44,8 @@ class Entity(BaseModel):
         Args:
             other: Entity to compare.
         """
+        if isinstance(other.id_, int) and isinstance(self.id_, int):
+            return self.id_ > other.id_
         return str(self.id_) > str(other.id_)
 
     def __hash__(self) -> int:

--- a/tests/unit/model/test_entity.py
+++ b/tests/unit/model/test_entity.py
@@ -4,9 +4,13 @@ from repository_orm import Entity
 
 
 def test_compare_less_than_entities() -> None:
-    """Comparison between entities is done by the ID attribute."""
-    small = Entity(id_=1)
-    big = Entity(id_=2)
+    """Comparison between entities is done by the ID attribute.
+
+    2 and 10 are deliberately chosen to avoid disordering if we transform id's to
+    strings.
+    """
+    small = Entity(id_=2)
+    big = Entity(id_=10)
 
     result = small < big
 
@@ -15,8 +19,8 @@ def test_compare_less_than_entities() -> None:
 
 def test_compare_greater_than_entities() -> None:
     """Comparison between entities is done by the ID attribute."""
-    small = Entity(id_=1)
-    big = Entity(id_=2)
+    small = Entity(id_=2)
+    big = Entity(id_=10)
 
     result = big > small
 


### PR DESCRIPTION
- fix: make cache entries immutable
- bump: version 0.9.0 → 0.9.1
- feat: add close method to the data repositories
- fix: select pdm path editable backed
- ci: use pdm to run the test examples
- ci: run the example tests with pdm
- bump: version 0.9.1 → 0.10.0
- chore: update dependency requirements
- chore: update dependency requirements
- chore: update dependency requirements
- chore: update dependency requirements
- chore: update dependency requirements
- fix: sort the result of `repo.all()`
- feat: allow comparison of entities with different `id_` types
- fix[tinydb]: don't return wrong object types on `last` even if they are staged
- bump: version 0.10.0 → 0.11.0
- fix: correct ordering of entities that both have an integer type

<!--
Thank you for sending a pull request!

Please describe what the change is, trying to link it with open issues.
-->

## Checklist

* [ ] Add test cases to all the changes you introduce
* [ ] Update the documentation for the changes
