### PR TITLE
fix: use Sequence as type hint for repo.add

### DIFF
--- a/src/repository_orm/adapters/data/abstract.py
+++ b/src/repository_orm/adapters/data/abstract.py
@@ -4,14 +4,15 @@ import abc
 import logging
 import warnings
 from contextlib import suppress
-from typing import Dict, List, Optional, Type, TypeVar, Union, overload
+from typing import Dict, List, Optional, Sequence, Type, TypeVar, Union
+
 from ...exceptions import AutoIncrementError, EntityNotFoundError
 from ...model import Entity as EntityModel
 from ...model import EntityID
 from .cache import Cache
 
 Entity = TypeVar("Entity", bound=EntityModel)
-EntityOrEntities = Union[List[EntityModel], EntityModel]
+EntityOrEntities = TypeVar("EntityOrEntities", Sequence[EntityModel], EntityModel)
 Models = List[Type[Entity]]
 OptionalModels = Optional[Models[Entity]]
 OptionalModelOrModels = Optional[Union[Type[Entity], Models[Entity]]]
@@ -54,16 +55,6 @@ class Repository(abc.ABC):
             )
         self.models = models
         self.cache = Cache()
-
-    @overload
-    def add(self, entities: EntityModel, merge: bool = False) -> EntityModel:
-        ...  # pragma: no cover
-
-    @overload
-    def add(
-        self, entities: List[EntityModel], merge: bool = False
-    ) -> List[EntityModel]:
-        ...  # pragma: no cover
 
     def add(self, entities: EntityOrEntities, merge: bool = False) -> EntityOrEntities:
         """Append an entity or list of entities to the repository.

--- a/src/repository_orm/adapters/data/cache.py
+++ b/src/repository_orm/adapters/data/cache.py
@@ -57,7 +57,7 @@ class Cache:
         if isinstance(entity_or_entities, EntityModel):
             entities = [entity_or_entities]
         else:
-            entities = entity_or_entities
+            entities = list(entity_or_entities)
 
         for entity in entities:
             with suppress(KeyError):

--- a/tests/unit/test_type_hints.py
+++ b/tests/unit/test_type_hints.py
@@ -1,0 +1,26 @@
+"""Test type hints issues."""
+
+from typing import List
+
+from tests.cases.entities import BookFactory
+from tests.cases.model import Book
+
+from repository_orm import FakeRepository
+
+
+def get_books() -> List[Book]:
+    """Return some books."""
+    return BookFactory.batch(5)
+
+
+def test_add_works_with_return_value_of_function(repo_fake: FakeRepository) -> None:
+    """
+    Given: A Fake repository and a function that returns a list of entities
+    When: Using repo.add on the result of the function
+    Then: no mypy error is returned
+    """
+    books = get_books()
+
+    result = repo_fake.add(books)
+
+    assert len(result) == 5


### PR DESCRIPTION
That way we can use the result of functions that return `List[Entity]`.

<!--
Thank you for sending a pull request!

Please describe what the change is, trying to link it with open issues.
-->

## Checklist

* [ ] Add test cases to all the changes you introduce
* [ ] Update the documentation for the changes
