### PR TITLE
fix: correct the search on tinydb when a value is None

### DIFF
--- a/src/repository_orm/adapters/data/tinydb.py
+++ b/src/repository_orm/adapters/data/tinydb.py
@@ -354,8 +354,11 @@ class TinyDBRepository(Repository):
         self.db_.truncate()
 
 
-def _regexp_in_list(list_: Iterable[Any], regular_expression: str) -> bool:
+def _regexp_in_list(list_: Optional[Iterable[Any]], regular_expression: str) -> bool:
     """Test if regexp matches any element of the list."""
+    if list_ is None:
+        return False
+
     regexp = re.compile(regular_expression)
 
     return any(regexp.search(element) for element in list_)


### PR DESCRIPTION
It was raising a TypeError when it shouldn't

<!--
Thank you for sending a pull request!

Please describe what the change is, trying to link it with open issues.
-->

## Checklist

* [ ] Add test cases to all the changes you introduce
* [ ] Update the documentation for the changes
